### PR TITLE
pyfixest 0.9.11

### DIFF
--- a/docs/news.md
+++ b/docs/news.md
@@ -1,5 +1,10 @@
 # News
 
+## PyFixest `0.9.11`
+
+- Bump required `formulaic` version to `0.6.5`.
+- Stop copying the data frame in `fixef()`.
+
 ## PyFixest `0.9.10`
 
 - Fixes a big in the `wildboottest` method (see [#158](https://github.com/s3alfisc/pyfixest/issues/158)).

--- a/poetry.lock
+++ b/poetry.lock
@@ -489,14 +489,14 @@ typing = ["typing-extensions (>=4.7.1)"]
 
 [[package]]
 name = "formulaic"
-version = "0.6.4"
+version = "0.6.5"
 description = "An implementation of Wilkinson formulas."
 category = "main"
 optional = false
 python-versions = ">=3.7.2"
 files = [
-    {file = "formulaic-0.6.4-py3-none-any.whl", hash = "sha256:570b3c7ab15fe8095e0dc86a4f71217102b23ce7e715053751a6cdcc580d7767"},
-    {file = "formulaic-0.6.4.tar.gz", hash = "sha256:a8c84b6fa6df9216dbeaddcfa3f097bd5efe88e340211ac34c18cffe133cdb78"},
+    {file = "formulaic-0.6.5-py3-none-any.whl", hash = "sha256:12890896fec86f80f1da713907e7b789f4d2c09fa06c4d5dc0ec4e5327e6e309"},
+    {file = "formulaic-0.6.5.tar.gz", hash = "sha256:7deeac5d74a0268e9e7e55988094f0ed13cf4e940a17a7eeb296a2cc67530c41"},
 ]
 
 [package.dependencies]
@@ -2325,4 +2325,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8,<4.0"
-content-hash = "d178a76a5b9d7ca3b6e2c0ab68d78906a04e6fdc1015e88bc963e33446f304ee"
+content-hash = "73c81967cad2471322ef5da1ab1c392f61b3c9f644024960dc0850a221e64aa9"

--- a/pyfixest/feols.py
+++ b/pyfixest/feols.py
@@ -719,7 +719,7 @@ class Feols:
         This method creates the following attributes:
 
         - `alphaDF` (pd.DataFrame): A DataFrame with the estimated fixed effects.
-        - `sumDF` (np.array): An array with the sum of fixed effects for each observation (i = 1, ..., N).
+        - `sumFE` (np.array): An array with the sum of fixed effects for each observation (i = 1, ..., N).
 
         Args:
             None
@@ -747,19 +747,18 @@ class Feols:
         depvars, res = _fml.split("~")
         covars, fixef_vars = res.split("|")
 
-        df = _data.copy()
-        # all fixef vars to pd.Categorical
-        for x in fixef_vars.split("+"):
-            df[x] = pd.Categorical(df[x])
+        fixef_vars = fixef_vars.split("+")
+        fixef_vars_C = [f"C({x})" for x in fixef_vars]
+        fixef_fml = "+".join(fixef_vars_C)
 
         fml_linear = f"{depvars} ~ {covars}"
-        Y, X = model_matrix(fml_linear, df)
+        Y, X = model_matrix(fml_linear, _data)
         X = X[self._coefnames]  # drop intercept, potentially multicollinear vars
         Y = Y.to_numpy().flatten().astype(np.float64)
         X = X.to_numpy()
         uhat = csr_matrix(Y - X @ self._beta_hat).transpose()
 
-        D2 = model_matrix("-1+" + fixef_vars, df, output="sparse")
+        D2 = model_matrix("-1+" + fixef_fml, _data, output="sparse")
         cols = D2.model_spec.column_names
 
         alpha = spsolve(D2.transpose() @ D2, D2.transpose() @ uhat)
@@ -829,7 +828,6 @@ class Feols:
                     self.fixef()
 
                 fvals = self._fixef.split("+")
-
                 df_fe = newdata[fvals].astype(str)
 
                 # populate matrix with fixed effects estimates
@@ -839,7 +837,9 @@ class Feols:
                 for i, fixef in enumerate(df_fe.columns):
                     new_levels = df_fe[fixef].unique()
                     old_levels = _data[fixef].unique().astype(str)
-                    subdict = self._fixef_dict[fixef]
+                    subdict = self._fixef_dict[
+                        f"C({fixef})"
+                    ]  # as variables are called C(var) in the fixef_dict
 
                     for level in new_levels:
                         # if level estimated: either estimated value (or 0 for reference level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
 name = "pyfixest"
-version = "0.9.10"
+version = "0.9.11"
 
 
-description = "Experimental draft package for high dimensional fixed effect estimation. Supports OLS and IV estimation."
+description = "(Not so) experimental draft package for high dimensional fixed effect estimation. Supports OLS, IV and Poisson regression and a range of inference procedures."
 authors = ["Alexander Fischer <alexander-fischer1801@t-online.de>"]
 license = "MIT"
 readme = "readme.md"
@@ -16,7 +16,7 @@ pandas=">=1.1.0"
 numpy=">=1.19.0"
 PyHDFE=">=0.2"
 scipy=">=1.6"
-formulaic=">=0.6.0"
+formulaic=">=0.6.5"
 pytest="^7.0.0"
 lets-plot = "^4.0.1"
 wildboottest={ version = ">=0.2", optional = true}


### PR DESCRIPTION
- Bump required `formulaic` version to `0.6.5`.
- Stop copying the data frame in `fixef()`.
