### PR TITLE
PyFixest 0.10.13: Faster CRV1 Inference

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -77,14 +77,14 @@ redis = ["redis (>=2.10.5)"]
 
 [[package]]
 name = "certifi"
-version = "2023.7.22"
+version = "2023.11.17"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = true
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2023.7.22-py3-none-any.whl", hash = "sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9"},
-    {file = "certifi-2023.7.22.tar.gz", hash = "sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082"},
+    {file = "certifi-2023.11.17-py3-none-any.whl", hash = "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"},
+    {file = "certifi-2023.11.17.tar.gz", hash = "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1"},
 ]
 
 [[package]]

--- a/pyfixest/feols.py
+++ b/pyfixest/feols.py
@@ -292,7 +292,6 @@ class Feols:
                 self._vcov = self._ssc * bread @ meat @ bread
 
         elif self._vcov_type == "CRV":
-
             cluster_df = _data[self._clustervar]
             if cluster_df.isna().any().any():
                 raise NanInClusterVarError(
@@ -340,17 +339,18 @@ class Feols:
                 self._ssc.append(ssc)
 
                 if self._vcov_type_detail == "CRV1":
-
                     if _weights is not None:
-                        weighted_uhat = (_weights.flatten() * _u_hat.flatten()).reshape((_N, 1))
+                        weighted_uhat = (_weights.flatten() * _u_hat.flatten()).reshape(
+                            (_N, 1)
+                        )
                     else:
                         weighted_uhat = _u_hat
 
                     meat = _crv1_meat_loop(
-                        _Z = _Z,
+                        _Z=_Z,
                         weighted_uhat=weighted_uhat,
-                        clustid = clustid.values,
-                        cluster_col = cluster_col.values
+                        clustid=clustid.values,
+                        cluster_col=cluster_col.values,
                     )
 
                     if _is_iv == False:
@@ -933,8 +933,6 @@ class Feols:
             adj_r2_within (float): Adjusted R-squared of the regression model, computed on demeaned dependent variable.
         """
 
-
-
         _Y = self._Y
         _u_hat = self._u_hat
         _N = self._N
@@ -943,7 +941,6 @@ class Feols:
             _n_fe = len(self._fixef)
         else:
             _n_fe = 0
-
 
         # (n - nb_fe) / (n - nb_fe - K)
         adjustment_factor = (_N - _n_fe) / (_N - _n_fe - _k)
@@ -958,7 +955,7 @@ class Feols:
 
         self._r2_within = 1 - (ssu / ssy_within)
         self._r2_within_adjusted = adjustment_factor * self._r2_within
-        self._r2 = None #1 - (ssu / ssy)
+        self._r2 = None  # 1 - (ssu / ssy)
 
     def tidy(self) -> pd.DataFrame:
         """
@@ -1228,6 +1225,7 @@ def _drop_multicollinear_variables(
 
     return X, names, collin_vars, collin_index
 
+
 def _find_collinear_variables(X, tol=1e-10):
     """
     Detect multicollinear variables.
@@ -1289,8 +1287,12 @@ def _find_collinear_variables(X, tol=1e-10):
 
 
 @nb.njit(parallel=True)
-def _crv1_meat_loop(_Z: np.ndarray, weighted_uhat: np.ndarray, clustid: np.ndarray, cluster_col: np.ndarray) -> np.ndarray:
-
+def _crv1_meat_loop(
+    _Z: np.ndarray,
+    weighted_uhat: np.ndarray,
+    clustid: np.ndarray,
+    cluster_col: np.ndarray,
+) -> np.ndarray:
     """
     Compute the meat matrix for CRV1 inference.
     Args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfixest"
-version = "0.10.12.0"
+version = "0.10.13.0"
 
 
 description = "Fast high dimensional fixed effect estimation following syntax of the fixest R package. Supports OLS, IV and Poisson regression and a range of inference procedures. Additionally, experimentally supports (some of) the regression based new Difference-in-Differences Estimators (Did2s)."


### PR DESCRIPTION
Increases the performance of CRV1 inference by jit compiling and parallelizing via `numba`.