### PR TITLE
Add justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -13,20 +13,13 @@ poetry-update:
 
 # Install development dependencies
 install-dev:
+	poetry env use 3.11
 	poetry config virtualenvs.in-project true
 	poetry install
-
-# Install pre-commit hooks
-install-hooks:
-	poetry run pre-commit install --install-hooks
 
 # Run pytest
 tests:
 	poetry run pytest
-
-# Run pytest with coverage
-tests-cov:
-	poetry run pytest --cov-report term --cov=pyfixest
 
 # Build the package
 build: tests

--- a/justfile
+++ b/justfile
@@ -17,6 +17,10 @@ install-dev:
 	poetry config virtualenvs.in-project true
 	poetry install
 
+# Install R dependencies
+install-r:
+	Rscript -e 'install.packages(c("broom", "clubSandwich", "did2s", "fixest"), repos="https://cran.rstudio.com")'
+
 # Run pytest
 tests:
 	poetry run pytest

--- a/justfile
+++ b/justfile
@@ -1,0 +1,53 @@
+# docs: justfile docs: https://just.systems/man/en/
+default:
+	just --list --unsorted
+
+# Clean environment
+[confirm]
+clean:
+	rm -rf .venv/
+
+# Update dependencies in pyproject.toml
+poetry-update:
+	poetry update
+
+# Install development dependencies
+install-dev:
+	poetry config virtualenvs.in-project true
+	poetry install
+
+# Install pre-commit hooks
+install-hooks:
+	poetry run pre-commit install --install-hooks
+
+# Run pytest
+tests:
+	poetry run pytest
+
+# Run pytest with coverage
+tests-cov:
+	poetry run pytest --cov-report term --cov=pyfixest
+
+# Build the package
+build: tests
+	poetry build
+
+# Build documentation and website
+docs-build:
+	poetry run quartodoc build --verbose --config docs/_quarto.yml
+
+# Render documentation and website
+render: docs-build
+	poetry run quarto render docs
+
+# Build the documentation and watch for changes
+docs-watch:
+	poetry run poetry run quartodoc build --watch --verbose --config docs/_quarto.yml
+
+# Preview the docs
+preview:
+	poetry run quarto preview docs
+
+# Clean docs build
+docs-clean:
+	rm -rf docs/_build docs/api/api_card


### PR DESCRIPTION
To help with development, I have added a Justfile (https://just.systems/). These targets, 

Could implement this with Make, however, configuring Make on Windows OS is considerably more challenging. Just works similarly on MacOS, Linux OS, and Windows OS. requires installing just via homebrew (mac/linux) or scoop/chocolatey (windows).

The targets are just suggestions, but they are ones that I've managed to get to work with the pyfixest repo. Currently testing on Linux. Feel free to cut, modify, or add to the targets.

I had trouble getting poetry to install dependencies with Python 3.12. So, I set poetry to install within a python 3.11 environment. @s3alfisc - Feel free to modify if there's a different Python version that you prefer for development.

```
install-dev:
	poetry env use 3.11
	poetry config virtualenvs.in-project true
	poetry install
```