### PR TITLE
publish docs on refs/heads/master

### DIFF
--- a/.github/workflows/ci-tests.yaml
+++ b/.github/workflows/ci-tests.yaml
@@ -85,7 +85,7 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     needs: ["build-docs", "test"]
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/master'
     steps:
       - name: Download docs artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
@s3alfisc Github Workflow ci-tests didn't publish docs because it was looking for the `main` branch, but the default branch is `master`. Fixing the typo.

Failed workflow: https://github.com/s3alfisc/pyfixest/actions/runs/7806862661

Apologies for the oversight! Looks like you got the quartodocs error resolved.