### PR TITLE
add ruff linting and formatting rules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,9 @@ repos:
     hooks:
       - id: check-github-workflows
         args: ["--verbose"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.2.1
+    hooks:
+      - id: ruff
+        name: ruff

--- a/pyfixest/FixestMulti.py
+++ b/pyfixest/FixestMulti.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union, dict, list
 
 import numpy as np
 import pandas as pd
@@ -48,13 +48,13 @@ class FixestMulti:
         self,
         estimation: str,
         fml: str,
-        vcov: Union[None, str, Dict[str, str]] = None,
+        vcov: Union[None, str, dict[str, str]] = None,
         weights: Union[None, np.ndarray] = None,
-        ssc: Dict[str, str] = {},
+        ssc: dict[str, str] = {},
         fixef_rm: str = "none",
         drop_intercept: bool = False,
-        i_ref1: Optional[Union[List, str]] = None,
-        i_ref2: Optional[Union[List, str]] = None,
+        i_ref1: Optional[Union[list, str]] = None,
+        i_ref2: Optional[Union[list, str]] = None,
     ) -> None:
         """
         Utility function to prepare estimation via the `feols()` or `fepois()` methods. The function is called by both methods.
@@ -63,14 +63,14 @@ class FixestMulti:
         Args:
             estimation (str): Type of estimation. Either "feols" or "fepois".
             fml (str): A three-sided formula string using fixest formula syntax. Supported syntax includes: see `feols()` or `fepois()`.
-            vcov (Union[None, str, Dict[str, str]], optional): A string or dictionary specifying the type of variance-covariance matrix to use for inference. See `feols()` or `fepois()`.
+            vcov (Union[None, str, dict[str, str]], optional): A string or dictionary specifying the type of variance-covariance matrix to use for inference. See `feols()` or `fepois()`.
             weights (Union[None, np.ndarray], optional): An array of weights. Either None or a 1D array of length N. Default is None.
-            ssc (Dict[str, str], optional): A dictionary specifying the type of standard errors to use for inference. See `feols()` or `fepois()`.
+            ssc (dict[str, str], optional): A dictionary specifying the type of standard errors to use for inference. See `feols()` or `fepois()`.
             fixef_rm (str, optional): A string specifying whether singleton fixed effects should be dropped.
                 Options are "none" (default) and "singleton". If "singleton", singleton fixed effects are dropped.
             drop_intercept (bool, optional): Whether to drop the intercept. Default is False.
-            i_ref1 (Optional[Union[List, str]], optional): A list or string specifying the reference category for the first interaction variable.
-            i_ref2 (Optional[Union[List, str]], optional): A list or string specifying the reference category for the second interaction variable.
+            i_ref1 (Optional[Union[list, str]], optional): A list or string specifying the reference category for the first interaction variable.
+            i_ref2 (Optional[Union[list, str]], optional): A list or string specifying the reference category for the second interaction variable.
 
         Returns:
             None
@@ -123,8 +123,8 @@ class FixestMulti:
 
     def _estimate_all_models(
         self,
-        vcov: Union[str, Dict[str, str], None],
-        fixef_keys: Union[List[str], None],
+        vcov: Union[str, dict[str, str], None],
+        fixef_keys: Union[list[str], None],
         collin_tol: float = 1e-6,
         iwls_maxiter: int = 25,
         iwls_tol: float = 1e-08,
@@ -133,12 +133,12 @@ class FixestMulti:
         Estimate multiple regression models.
 
         Args:
-            vcov (Union[str, Dict[str, str]]): A string or dictionary specifying the type of variance-covariance
+            vcov (Union[str, dict[str, str]]): A string or dictionary specifying the type of variance-covariance
                 matrix to use for inference.
                 - If a string, can be one of "iid", "hetero", "HC1", "HC2", "HC3".
                 - If a dictionary, it should have the format {"CRV1": "clustervar"} for CRV1 inference
                   or {"CRV3": "clustervar"} for CRV3 inference.
-            fixef_keys (List[str]): A list of fixed effects combinations.
+            fixef_keys (list[str]): A list of fixed effects combinations.
             collin_tol (float, optional): The tolerance level for the multicollinearity check. Default is 1e-6.
             iwls_maxiter (int, optional): The maximum number of iterations for the IWLS algorithm. Default is 25.
                 Only relevant for non-linear estimation strategies.
@@ -244,10 +244,10 @@ class FixestMulti:
                         if not _is_iv:
                             Zd = Xd
 
-                        Yd, Xd, Zd, endogvard = [
+                        Yd, Xd, Zd, endogvard = (
                             x.to_numpy() if x is not None else x
                             for x in [Yd, Xd, Zd, endogvard]
-                        ]
+                        )
 
                         if _is_iv:
                             coefnames_z = Z.columns.tolist()
@@ -295,7 +295,7 @@ class FixestMulti:
                                 X.drop(na_separation, axis=0, inplace=True)
                                 fe.drop(na_separation, axis=0, inplace=True)
 
-                        Y, X = [x.to_numpy() for x in [Y, X]]
+                        Y, X = (x.to_numpy() for x in [Y, X])
                         N = X.shape[0]
 
                         if fe is not None:
@@ -396,7 +396,7 @@ class FixestMulti:
 
         return list(self.all_fitted_models.values())
 
-    def vcov(self, vcov: Union[str, Dict[str, str]]):
+    def vcov(self, vcov: Union[str, dict[str, str]]):
         """
         Update regression inference "on the fly".
 
@@ -404,7 +404,7 @@ class FixestMulti:
         to the "Fixest" object are replaced with the variance-covariance matrix specified via the method.
 
         Args:
-            vcov (Union[str, Dict[str, str]]): A string or dictionary specifying the type of variance-covariance
+            vcov (Union[str, dict[str, str]]): A string or dictionary specifying the type of variance-covariance
                 matrix to use for inference.
                 - If a string, can be one of "iid", "hetero", "HC1", "HC2", "HC3".
                 - If a dictionary, it should have the format {"CRV1": "clustervar"} for CRV1 inference

--- a/pyfixest/FixestMulti.py
+++ b/pyfixest/FixestMulti.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Union, dict, list
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -93,11 +93,9 @@ class FixestMulti:
             self._has_weights = True
 
         # set i_ref1 and i_ref2 to list if not None
-        if i_ref1 is not None:
-            if not isinstance(i_ref1, list):
+        if i_ref1 is not None and not isinstance(i_ref1, list):
                 i_ref1 = [i_ref1]
-        if i_ref2 is not None:
-            if not isinstance(i_ref2, list):
+        if i_ref2 is not None and not isinstance(i_ref2, list):
                 i_ref2 = [i_ref2]
 
         fxst_fml = FixestFormulaParser(fml)
@@ -168,7 +166,7 @@ class FixestMulti:
             lookup_demeaned_data = dict()
 
             # loop over both dictfe and dictfe_iv (if the latter is not None)
-            for depvar in dict2fe.keys():
+            for depvar in dict2fe:
                 for _, fml_linear in enumerate(dict2fe.get(depvar)):
                     covar = fml_linear.split("~")[1]
                     endogvars, instruments = None, None
@@ -217,10 +215,7 @@ class FixestMulti:
 
                     coefnames = X.columns.tolist()
 
-                    if fe is not None:
-                        _k_fe = fe.nunique(axis=0)
-                    else:
-                        _k_fe = None
+                    _k_fe = fe.nunique(axis=0) if fe is not None else None
 
                     if _method == "feols":
                         # demean Y, X, Z, if not already done in previous estimation
@@ -350,9 +345,8 @@ class FixestMulti:
                         FIT.get_inference()
 
                         # other regression stats
-                        if _method == "feols":
-                            if not FIT._is_iv:
-                                FIT.get_performance()
+                        if _method == "feols" and not FIT._is_iv:
+                            FIT.get_performance()
 
                         if _icovars is not None:
                             FIT._icovars = _icovars
@@ -700,15 +694,8 @@ def get_fml(
 
     fml = f"{depvar} ~ {covar}"
 
-    if endogvars is not None:
-        fml_iv = f"| {endogvars} ~ {instruments}"
-    else:
-        fml_iv = None
-
-    if fval != "0":
-        fml_fval = f"| {fval}"
-    else:
-        fml_fval = None
+    fml_iv = f"| {endogvars} ~ {instruments}" if endogvars is not None else None
+    fml_fval = f"| {fval}" if fval != "0" else None
 
     if fml_fval is not None:
         fml += fml_fval

--- a/pyfixest/FixestMulti.py
+++ b/pyfixest/FixestMulti.py
@@ -1,19 +1,18 @@
 import warnings
+from typing import Dict, List, Optional, Union
 
 import numpy as np
 import pandas as pd
-from typing import Union, Dict, Optional, List
 
+from pyfixest.demean import demean_model
+from pyfixest.dev_utils import _polars_to_pandas
+from pyfixest.exceptions import MultiEstNotSupportedError
+from pyfixest.feiv import Feiv
 from pyfixest.feols import Feols
 from pyfixest.fepois import Fepois, _check_for_separation
-from pyfixest.feiv import Feiv
-from pyfixest.model_matrix_fixest import model_matrix_fixest
-from pyfixest.demean import demean_model
 from pyfixest.FormulaParser import FixestFormulaParser
-from pyfixest.utils import ssc
-from pyfixest.exceptions import MultiEstNotSupportedError
-from pyfixest.visualize import iplot, coefplot
-from pyfixest.dev_utils import DataFrameType, _polars_to_pandas
+from pyfixest.model_matrix_fixest import model_matrix_fixest
+from pyfixest.visualize import coefplot, iplot
 
 
 class FixestMulti:
@@ -380,7 +379,7 @@ class FixestMulti:
             self._is_multiple_estimation = True
             if self._is_iv:
                 raise MultiEstNotSupportedError(
-                    f"""
+                    """
                         Multiple Estimations is currently not supported with IV.
                         This is mostly due to insufficient testing and will be possible with a future release of PyFixest.
                         """

--- a/pyfixest/FormulaParser.py
+++ b/pyfixest/FormulaParser.py
@@ -65,10 +65,8 @@ class FixestFormulaParser:
                         "Instruments are specified as covariates in the first part of the three-part formula. This is not allowed."
                     )
 
-                if covars == "1":
-                    covars = endogvars
-                else:
-                    covars = f"{endogvars}+{covars}"
+                covars = endogvars if covars == "1" else f"{endogvars}+{covars}"
+
             else:
                 fevars = fml_split[1]
                 endogvars = None

--- a/pyfixest/FormulaParser.py
+++ b/pyfixest/FormulaParser.py
@@ -1,4 +1,5 @@
 import re
+
 from pyfixest.exceptions import (
     DuplicateKeyError,
     EndogVarsAsCovarsError,

--- a/pyfixest/demean.py
+++ b/pyfixest/demean.py
@@ -78,7 +78,7 @@ def demean_model(
                     var_diff = var_diff.reshape(len(var_diff), 1)
 
                 YX_demean_new, success = demean(var_diff, fe, weights)
-                if success == False:
+                if not success:
                     raise ValueError("Demeaning failed after 100_000 iterations.")
 
                 YX_demeaned = pd.DataFrame(YX_demean_new)
@@ -97,7 +97,7 @@ def demean_model(
 
         else:
             YX_demeaned, success = demean(x=YX, flist=fe, weights=weights)
-            if success == False:
+            if not success:
                 raise ValueError("Demeaning failed after 100_000 iterations.")
 
             YX_demeaned = pd.DataFrame(YX_demeaned)

--- a/pyfixest/demean.py
+++ b/pyfixest/demean.py
@@ -1,9 +1,8 @@
-from typing import Any, Dict, Optional, Sequence, Tuple
+from typing import Any, Dict, Optional, Tuple
 
 import numba as nb
 import numpy as np
 import pandas as pd
-from numba.extending import overload
 
 
 def demean_model(

--- a/pyfixest/demean.py
+++ b/pyfixest/demean.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional, dict, tuple
+from typing import Any, Optional
 
 import numba as nb
 import numpy as np

--- a/pyfixest/demean.py
+++ b/pyfixest/demean.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Optional, dict, tuple
 
 import numba as nb
 import numpy as np
@@ -10,9 +10,9 @@ def demean_model(
     X: pd.DataFrame,
     fe: Optional[pd.DataFrame],
     weights: Optional[np.ndarray],
-    lookup_demeaned_data: Dict[str, Any],
+    lookup_demeaned_data: dict[str, Any],
     na_index_str: str,
-) -> Tuple[pd.DataFrame, pd.DataFrame, Optional[pd.DataFrame]]:
+) -> tuple[pd.DataFrame, pd.DataFrame, Optional[pd.DataFrame]]:
     """
     Demeans a single regression model via the alterating projections algorithm (see `demean` function). Prior to demeaning, the function checks if some of the variables have already been demeaned and uses values from the cache `lookup_demeaned_data` if possible. If the model has no fixed effects, the function does not demean the data.
 
@@ -26,7 +26,7 @@ def demean_model(
         A DataFrame of the fixed effects. None if no fixed effects specified.
     weights : np.ndarray or None
         A numpy array of weights. None if no weights.
-    lookup_demeaned_data : Dict[str, Any]
+    lookup_demeaned_data : dict[str, Any]
         A dictionary with keys for each fixed effects combination and potentially values of demeaned data frames.
         The function checks this dictionary to see if some of the variables have already been demeaned.
     na_index_str : str
@@ -34,7 +34,7 @@ def demean_model(
 
     Returns
     -------
-    Tuple[pd.DataFrame, pd.DataFrame, Optional[pd.DataFrame]]
+    tuple[pd.DataFrame, pd.DataFrame, Optional[pd.DataFrame]]
         A tuple of the following elements:
         - Yd : pd.DataFrame
             A DataFrame of the demeaned dependent variable.
@@ -167,7 +167,7 @@ def demean(
     weights: np.ndarray,
     tol: float = 1e-08,
     maxiter: int = 100_000,
-) -> Tuple[np.ndarray, bool]:
+) -> tuple[np.ndarray, bool]:
     """
     Workhorse for demeaning an input array `x` based on the specified fixed effects and weights
     via the alternating projections algorithm.
@@ -188,7 +188,7 @@ def demean(
 
     Returns
     -------
-    Tuple[np.ndarray, bool]
+    tuple[np.ndarray, bool]
         A tuple containing the demeaned array of shape (n_samples, n_features)
         and a boolean indicating whether the algorithm converged successfully.
     """

--- a/pyfixest/dev_utils.py
+++ b/pyfixest/dev_utils.py
@@ -1,5 +1,6 @@
-import pandas as pd
 from typing import Union
+
+import pandas as pd
 
 try:
     import polars as pl

--- a/pyfixest/dev_utils.py
+++ b/pyfixest/dev_utils.py
@@ -1,3 +1,4 @@
+import importlib.util
 from typing import Union
 
 import pandas as pd
@@ -12,13 +13,12 @@ except ImportError:
 
 def _polars_to_pandas(data: DataFrameType) -> pd.DataFrame:
     if not isinstance(data, pd.DataFrame):
-        try:
-            import polars as pl
-
-            data = data.to_pandas()
-        except ImportError:
+        polars_spec = importlib.util.find_spec("polars")
+        if polars_spec is not None:
+            return data.to_pandas()
+        else:
             raise ImportError(
                 "Polars is not installed. Please install Polars to use it as an alternative."
             )
-
     return data
+

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Union, list
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional, Union
+from typing import Optional, Union, list
 
 import numpy as np
 import pandas as pd
@@ -114,8 +114,8 @@ def _did2s_estimate(
     _first_stage: str,
     _second_stage: str,
     treatment: str,
-    i_ref1: Optional[Union[int, str, List]] = None,
-    i_ref2: Optional[Union[int, str, List]] = None,
+    i_ref1: Optional[Union[int, str, list]] = None,
+    i_ref2: Optional[Union[int, str, list]] = None,
 ):
     """
     Args:
@@ -154,9 +154,9 @@ def _did2s_estimate(
                     raise ValueError(
                         f"The treatment variable {treatment} must be boolean."
                     )
-        _not_yet_treated_data = data[data[treatment] == False]
+        _not_yet_treated_data = data[~data[treatment]]
     else:
-        _not_yet_treated_data = data[data["ATT"] == False]
+        _not_yet_treated_data = data[~data["ATT"]]
 
     # check if first stage formulas has fixed effects
     if "|" not in _first_stage:
@@ -205,8 +205,8 @@ def _did2s_vcov(
     first_u: np.ndarray,
     second_u: np.ndarray,
     cluster: str,
-    i_ref1: Optional[Union[int, str, List]] = None,
-    i_ref2: Optional[Union[int, str, List]] = None,
+    i_ref1: Optional[Union[int, str, list]] = None,
+    i_ref2: Optional[Union[int, str, list]] = None,
 ):
     """
     Compute a variance covariance matrix for Gardner's 2-stage Difference-in-Differences Estimator.

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -1,14 +1,14 @@
-import pandas as pd
+import warnings
+from typing import List, Optional, Union
+
 import numpy as np
+import pandas as pd
+from scipy.sparse import csr_matrix
+from scipy.sparse.linalg import spsolve
 
 from pyfixest.did.did import DID
 from pyfixest.estimation import feols
 from pyfixest.model_matrix_fixest import model_matrix_fixest
-
-from scipy.sparse import csr_matrix
-from scipy.sparse.linalg import spsolve
-import warnings
-from typing import Optional, Union, List
 
 
 class DID2S(DID):
@@ -47,7 +47,7 @@ class DID2S(DID):
             self._fml2 = f" ~ 0 + ATT + {xfml}"
         else:
             self._fml1 = f" ~ 0 | {idname} + {tname}"
-            self._fml2 = f" ~ 0 + ATT"
+            self._fml2 = " ~ 0 + ATT"
 
     def estimate(self):
         """

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -1,8 +1,10 @@
+from typing import Dict, List, Optional, Union
+
 import pandas as pd
-from typing import Optional, Union, List, Dict
-from pyfixest.did.did2s import _did2s_estimate, _did2s_vcov, DID2S
-from pyfixest.did.twfe import TWFE
+
+from pyfixest.did.did2s import DID2S, _did2s_estimate, _did2s_vcov
 from pyfixest.did.lpdid import LPDID
+from pyfixest.did.twfe import TWFE
 from pyfixest.exceptions import NotImplementedError
 
 

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union, dict, list
 
 import pandas as pd
 
@@ -141,8 +141,8 @@ def did2s(
     second_stage: str,
     treatment: str,
     cluster: str,
-    i_ref1: Optional[Union[int, str, List]] = None,
-    i_ref2: Optional[Union[int, str, List]] = None,
+    i_ref1: Optional[Union[int, str, list]] = None,
+    i_ref2: Optional[Union[int, str, list]] = None,
 ):
     """
     Estimate a Difference-in-Differences model using Gardner's two-step DID2S estimator.
@@ -277,7 +277,7 @@ def lpdid(
     idname: str,
     tname: str,
     gname: str,
-    vcov: Optional[Union[str, Dict[str, str]]] = None,
+    vcov: Optional[Union[str, dict[str, str]]] = None,
     pre_window: Optional[int] = None,
     post_window: Optional[int] = None,
     never_treated: int = 0,

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, dict, list
+from typing import Optional, Union
 
 import pandas as pd
 

--- a/pyfixest/did/event_study.py
+++ b/pyfixest/did/event_study.py
@@ -1,7 +1,8 @@
 import pandas as pd
-from pyfixest.exceptions import NotImplementedError
+
 from pyfixest.did.did2s import DID2S
 from pyfixest.did.twfe import TWFE
+from pyfixest.exceptions import NotImplementedError
 
 
 def event_study(

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, dict
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -1,11 +1,11 @@
-import pandas as pd
-import numpy as np
+from typing import Dict, Optional, Union
 
+import numpy as np
+import pandas as pd
+
+from pyfixest.did.did import DID
 from pyfixest.estimation import feols
 from pyfixest.visualize import _coefplot
-from pyfixest.did.did import DID
-
-from typing import Optional, Union, Dict
 
 
 class LPDID(DID):

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Optional, Union, dict
 
 import numpy as np
 import pandas as pd
@@ -127,7 +127,7 @@ def _lpdid_estimate(
     yname: str,
     idname: str,
     tname: str,
-    vcov: Optional[Union[str, Dict[str, str]]] = None,
+    vcov: Optional[Union[str, dict[str, str]]] = None,
     pre_window: Optional[int] = None,
     post_window: Optional[int] = None,
     att: bool = True,

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -159,7 +159,6 @@ def _lpdid_estimate(
     # code for the lpdid package: https://github.com/alexCardazzi/lpdid
 
     fit_all = []
-    reweight = False
 
     if xfml is None:
         fml = f"Dy ~ treat_diff | {tname}"

--- a/pyfixest/did/twfe.py
+++ b/pyfixest/did/twfe.py
@@ -1,6 +1,5 @@
-from pyfixest.estimation import feols
-from pyfixest.exceptions import NotImplementedError
 from pyfixest.did.did import DID
+from pyfixest.estimation import feols
 
 
 class TWFE(DID):

--- a/pyfixest/estimation.py
+++ b/pyfixest/estimation.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, dict
+from typing import Optional, Union
 
 import pandas as pd
 

--- a/pyfixest/estimation.py
+++ b/pyfixest/estimation.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Union
+from typing import Optional, Union, dict
 
 import pandas as pd
 
@@ -12,7 +12,7 @@ from pyfixest.utils import ssc
 def feols(
     fml: str,
     data: DataFrameType,
-    vcov: Optional[Union[str, Dict[str, str]]] = None,
+    vcov: Optional[Union[str, dict[str, str]]] = None,
     weights: Union[None, str] = None,
     ssc=ssc(),
     fixef_rm: str = "none",
@@ -228,7 +228,7 @@ def feols(
 def fepois(
     fml: str,
     data: DataFrameType,
-    vcov: Optional[Union[str, Dict[str, str]]] = None,
+    vcov: Optional[Union[str, dict[str, str]]] = None,
     ssc=ssc(),
     fixef_rm: str = "none",
     iwls_tol: float = 1e-08,

--- a/pyfixest/estimation.py
+++ b/pyfixest/estimation.py
@@ -1,12 +1,12 @@
-from typing import Optional, Union, Dict
-from pyfixest.utils import ssc
-from pyfixest.FixestMulti import FixestMulti
-from pyfixest.fepois import Fepois
-from pyfixest.feols import Feols
-from pyfixest.dev_utils import DataFrameType
+from typing import Dict, Optional, Union
 
 import pandas as pd
-import numpy as np
+
+from pyfixest.dev_utils import DataFrameType
+from pyfixest.feols import Feols
+from pyfixest.fepois import Fepois
+from pyfixest.FixestMulti import FixestMulti
+from pyfixest.utils import ssc
 
 
 def feols(
@@ -358,7 +358,7 @@ def _estimation_input_checks(
     if not isinstance(collin_tol, float):
         raise ValueError("collin_tol must be a float")
 
-    if not fixef_rm in ["none", "singleton"]:
+    if fixef_rm not in ["none", "singleton"]:
         raise ValueError("fixef_rm must be either 'none' or 'singleton'")
     if not collin_tol > 0:
         raise ValueError("collin_tol must be greater than zero")

--- a/pyfixest/feiv.py
+++ b/pyfixest/feiv.py
@@ -1,5 +1,7 @@
-import numpy as np
 from typing import Optional
+
+import numpy as np
+
 from pyfixest.feols import Feols, _drop_multicollinear_variables
 
 

--- a/pyfixest/feols.py
+++ b/pyfixest/feols.py
@@ -392,7 +392,7 @@ class Feols:
                 else:
                     transformed_scores = _scores / (1 - leverage)[:, None]
 
-            if _is_iv == False:
+            if not _is_iv:
                 meat = transformed_scores.transpose() @ transformed_scores
                 self._vcov = self._ssc * bread @ meat @ bread
             else:
@@ -468,7 +468,7 @@ class Feols:
                         cluster_col=cluster_col,
                     )
 
-                    if _is_iv == False:
+                    if not _is_iv:
                         self._vcov += self._ssc[x] * bread @ meat @ bread
                     else:
                         meat = _tXZ @ _tZZinv @ meat @ _tZZinv @ self._tZX
@@ -487,9 +487,9 @@ class Feols:
                     beta_jack = np.zeros((len(clustid), _k))
 
                     if (
-                        (self._has_fixef == False)
+                        (not self._has_fixef)
                         and (self._method == "feols")
-                        and (_is_iv == False)
+                        and (not _is_iv)
                     ):
                         # inverse hessian precomputed?
                         tXX = np.transpose(self._X) @ self._X
@@ -1128,7 +1128,7 @@ class Feols:
             newdata = _polars_to_pandas(newdata).reset_index(drop=False)
 
             if self._has_fixef:
-                fml_linear, _ = _fml.split("|")
+                _ , _ = _fml.split("|")
 
                 if self._sumFE is None:
                     self.fixef()
@@ -1157,10 +1157,6 @@ class Feols:
                         # if new level not estimated: set to NaN
                         else:
                             fixef_mat[df_fe[fixef] == level, i] = np.nan
-
-            else:
-                fml_linear = _fml
-                fml_fe = None
 
             if not self._X_is_empty:
                 # deal with linear part

--- a/pyfixest/feols.py
+++ b/pyfixest/feols.py
@@ -1,7 +1,7 @@
 import re
 import warnings
 from importlib import import_module
-from typing import Optional, Union, dict, list, tuple
+from typing import Optional, Union
 
 import numba as nb
 import numpy as np
@@ -1431,9 +1431,7 @@ def _deparse_vcov_input(vcov, has_fixef, is_iv):
         if isinstance(deparse_vcov, str):
             deparse_vcov = [deparse_vcov]
         deparse_vcov = [x.replace(" ", "") for x in deparse_vcov]
-    elif isinstance(vcov, list):
-        vcov_type_detail = vcov
-    elif isinstance(vcov, str):
+    elif isinstance(vcov, list) or isinstance(vcov, str):
         vcov_type_detail = vcov
     else:
         assert False, "arg vcov needs to be a dict, string or list"

--- a/pyfixest/feols.py
+++ b/pyfixest/feols.py
@@ -1,25 +1,22 @@
 import re
 import warnings
+from importlib import import_module
+from typing import Dict, List, Optional, Tuple, Union
+
+import numba as nb
 import numpy as np
 import pandas as pd
-import warnings
-import numba as nb
-
-from importlib import import_module
-from typing import Optional, Union, List, Dict, Tuple
-from pyfixest.dev_utils import DataFrameType
-
-from scipy.stats import norm, t, chi2, f
-from scipy.sparse.linalg import spsolve
-from scipy.sparse import csr_matrix
 from formulaic import model_matrix
+from scipy.sparse import csr_matrix
+from scipy.sparse.linalg import spsolve
+from scipy.stats import f, norm, t
 
-from pyfixest.utils import get_ssc
+from pyfixest.dev_utils import DataFrameType, _polars_to_pandas
 from pyfixest.exceptions import (
-    VcovTypeNotSupportedError,
     NanInClusterVarError,
+    VcovTypeNotSupportedError,
 )
-from pyfixest.dev_utils import _polars_to_pandas
+from pyfixest.utils import get_ssc
 
 
 class Feols:

--- a/pyfixest/feols.py
+++ b/pyfixest/feols.py
@@ -1,7 +1,7 @@
 import re
 import warnings
 from importlib import import_module
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Optional, Union, dict, list, tuple
 
 import numba as nb
 import numpy as np
@@ -39,7 +39,7 @@ class Feols:
         Weights, a one-dimensional numpy array.
     collin_tol : float
         Tolerance level for collinearity checks.
-    coefnames : List[str]
+    coefnames : list[str]
         Names of the coefficients (of the design matrix X).
 
     Attributes
@@ -86,7 +86,7 @@ class Feols:
     _icovars : Any
         Internal covariates, to be enriched outside of the class.
     _ssc_dict : dict
-        Dictionary for sum of squares and cross products matrices.
+        dictionary for sum of squares and cross products matrices.
     _tZX : np.ndarray
         Transpose of Z multiplied by X, set in get_fit().
     _tXZ : np.ndarray
@@ -134,7 +134,7 @@ class Feols:
     _F_stat : Any
         F-statistic for the model, set in get_Ftest().
     _fixef_dict : dict
-        Dictionary containing fixed effects estimates.
+        dictionary containing fixed effects estimates.
     _sumFE : np.ndarray
         Sum of all fixed effects for each observation.
     _rmse : float
@@ -156,7 +156,7 @@ class Feols:
         X: np.ndarray,
         weights: np.ndarray,
         collin_tol: float,
-        coefnames: List[str],
+        coefnames: list[str],
         weights_name: Optional[str],
     ) -> None:
         self._method = "feols"
@@ -281,13 +281,13 @@ class Feols:
         self._tXZ = None
         self._tZZinv = None
 
-    def vcov(self, vcov: Union[str, Dict[str, str]]):
+    def vcov(self, vcov: Union[str, dict[str, str]]):
         """
         Compute covariance matrices for an estimated regression model.
 
         Parameters
         ----------
-        vcov : Union[str, Dict[str, str]]
+        vcov : Union[str, dict[str, str]]
             A string or dictionary specifying the type of variance-covariance matrix to use for inference.
             If a string, it can be one of "iid", "hetero", "HC1", "HC2", "HC3". If a dictionary,
             it should have the format {"CRV1": "clustervar"} for CRV1 inference or {"CRV3": "clustervar"}
@@ -688,7 +688,7 @@ class Feols:
                 "Note that the argument q is experimental and no unit tests are implemented. Please use with caution / take a look at the source code."
             )
         else:
-            q = np.zeros((R.shape[0]))
+            q = np.zeros(R.shape[0])
 
         assert distribution in [
             "F",
@@ -718,11 +718,11 @@ class Feols:
     def coefplot(
         self,
         alpha: float = 0.05,
-        figsize: Tuple[int, int] = (500, 300),
+        figsize: tuple[int, int] = (500, 300),
         yintercept: Optional[float] = 0,
         xintercept: Optional[float] = None,
         rotate_xticks: int = 0,
-        coefficients: Optional[List[str]] = None,
+        coefficients: Optional[list[str]] = None,
         title: Optional[str] = None,
         coord_flip: Optional[bool] = True,
     ):
@@ -733,7 +733,7 @@ class Feols:
         ----------
         alpha : float, optional
             Significance level for highlighting significant coefficients. Defaults to None.
-        figsize : Tuple[int, int], optional
+        figsize : tuple[int, int], optional
             Size of the plot (width, height) in inches. Defaults to None.
         yintercept : float, optional
             Value to set as the y-axis intercept (vertical line). Defaults to None.
@@ -741,8 +741,8 @@ class Feols:
             Value to set as the x-axis intercept (horizontal line). Defaults to None.
         rotate_xticks : int, optional
             Rotation angle for x-axis tick labels. Defaults to None.
-        coefficients : List[str], optional
-            List of coefficients to include in the plot. If None, all coefficients are included.
+        coefficients : list[str], optional
+            list of coefficients to include in the plot. If None, all coefficients are included.
         title : str, optional
             Title of the plot. Defaults to None.
         coord_flip : bool, optional
@@ -775,7 +775,7 @@ class Feols:
     def iplot(
         self,
         alpha: float = 0.05,
-        figsize: Tuple[int, int] = (500, 300),
+        figsize: tuple[int, int] = (500, 300),
         yintercept: Optional[float] = None,
         xintercept: Optional[float] = None,
         rotate_xticks: int = 0,
@@ -789,7 +789,7 @@ class Feols:
         ----------
         alpha : float, optional
             Significance level for visualization options. Defaults to None.
-        figsize : Tuple[int, int], optional
+        figsize : tuple[int, int], optional
             Size of the plot (width, height) in inches. Defaults to None.
         yintercept : float, optional
             Value to set as the y-axis intercept (vertical line). Defaults to None.
@@ -1529,7 +1529,7 @@ def _get_vcov_type(vcov, fval):
 
 
 def _drop_multicollinear_variables(
-    X: np.ndarray, names: List[str], collin_tol: float
+    X: np.ndarray, names: list[str], collin_tol: float
 ) -> None:
     """
     Checks for multicollinearity in the design matrices X and Z.
@@ -1538,7 +1538,7 @@ def _drop_multicollinear_variables(
     ----------
     X : numpy.ndarray
         The design matrix X.
-    names : List[str]
+    names : list[str]
         The names of the coefficients.
     collin_tol : float
         The tolerance level for the multicollinearity check.
@@ -1547,9 +1547,9 @@ def _drop_multicollinear_variables(
     -------
     Xd : numpy.ndarray
         The design matrix X after checking for multicollinearity.
-    names : List[str]
+    names : list[str]
         The names of the coefficients, excluding those identified as collinear.
-    collin_vars : List[str]
+    collin_vars : list[str]
         The collinear variables identified during the check.
     collin_index : numpy.ndarray
         Logical array, where True indicates that the variable is collinear.
@@ -1656,7 +1656,7 @@ def _find_collinear_variables(X, tol=1e-10):
 
 # CODE from Styfen Schaer (@styfenschaer)
 @nb.njit(parallel=False)
-def bucket_argsort(arr: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+def bucket_argsort(arr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     counts = np.zeros(arr.max() + 1, dtype=np.uint32)
     for i in range(arr.size):
         counts[arr[i]] += 1

--- a/pyfixest/fepois.py
+++ b/pyfixest/fepois.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import List, Optional
+from typing import Optional, list
 
 import numpy as np
 import pandas as pd
@@ -35,7 +35,7 @@ class Fepois(Feols):
         Fixed effects, a two-dimensional numpy array or None.
     weights : np.ndarray
         Weights, a one-dimensional numpy array or None.
-    coefnames : List[str]
+    coefnames : list[str]
         Names of the coefficients in the design matrix X.
     drop_singletons : bool
         Whether to drop singleton fixed effects.
@@ -55,7 +55,7 @@ class Fepois(Feols):
         X: np.ndarray,
         fe: np.ndarray,
         weights: np.ndarray,
-        coefnames: List[str],
+        coefnames: list[str],
         drop_singletons: bool,
         collin_tol: float,
         maxiter: Optional[int] = 25,
@@ -292,7 +292,7 @@ class Fepois(Feols):
         return y_hat
 
 
-def _check_for_separation(Y: pd.DataFrame, fe: pd.DataFrame, check: str = "fe") -> List:
+def _check_for_separation(Y: pd.DataFrame, fe: pd.DataFrame, check: str = "fe") -> list:
     """
     Check for separation of Poisson Regression. For details, see the pplmhdfe documentation on
     separation checks. Currently, only the "fe" check is implemented.
@@ -308,8 +308,8 @@ def _check_for_separation(Y: pd.DataFrame, fe: pd.DataFrame, check: str = "fe") 
 
     Returns
     -------
-    List
-        List of indices of observations that are removed due to separation.
+    list
+        list of indices of observations that are removed due to separation.
     """
 
     if check == "fe":

--- a/pyfixest/fepois.py
+++ b/pyfixest/fepois.py
@@ -145,7 +145,7 @@ class Fepois(Feols):
                 ).flatten()
             return deviance
 
-        accelerate = True
+        accelerate = False
         # inner_tol = 1e-04
         stop_iterating = False
         crit = 1
@@ -164,15 +164,11 @@ class Fepois(Feols):
                 mu = (_Y + _mean) / 2
                 eta = np.log(mu)
                 Z = eta + _Y / mu - 1
-                last_Z = Z.copy()
                 reg_Z = Z.copy()
                 last = compute_deviance(_Y, mu)
 
             elif accelerate:
-                last_Z = Z.copy()
-                Z = eta + _Y / mu - 1
-                reg_Z = Z - last_Z + Z_resid
-                X = X_resid.copy()
+                raise ValueError("Acceleration is not yet implemented for Poisson regression.")
 
             else:
                 # update w and Z
@@ -189,7 +185,7 @@ class Fepois(Feols):
             if _fe is not None:
                 # ZX_resid = algorithm.residualize(ZX, mu)
                 ZX_resid, success = demean(x=ZX, flist=_fe, weights=mu.flatten())
-                if success == False:
+                if not success:
                     raise ValueError("Demeaning failed after 100_000 iterations.")
             else:
                 ZX_resid = ZX

--- a/pyfixest/fepois.py
+++ b/pyfixest/fepois.py
@@ -1,15 +1,15 @@
+import warnings
+from typing import List, Optional
+
 import numpy as np
 import pandas as pd
-import warnings
 
-
-from typing import Union, Optional, List
-from pyfixest.feols import Feols
 from pyfixest.demean import demean
 from pyfixest.exceptions import (
     NonConvergenceError,
     NotImplementedError,
 )
+from pyfixest.feols import Feols
 
 
 class Fepois(Feols):

--- a/pyfixest/fepois.py
+++ b/pyfixest/fepois.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, list
+from typing import Optional
 
 import numpy as np
 import pandas as pd

--- a/pyfixest/model_matrix_fixest.py
+++ b/pyfixest/model_matrix_fixest.py
@@ -1,6 +1,6 @@
 import re
 import warnings
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union, list, tuple
 
 import numpy as np
 import pandas as pd
@@ -16,9 +16,9 @@ def model_matrix_fixest(
     drop_singletons: bool = False,
     weights: Optional[str] = None,
     drop_intercept=False,
-    i_ref1: Optional[Union[List, str, int]] = None,
-    i_ref2: Optional[Union[List, str, int]] = None,
-) -> Tuple[
+    i_ref1: Optional[Union[list, str, int]] = None,
+    i_ref2: Optional[Union[list, str, int]] = None,
+) -> tuple[
     pd.DataFrame,  # Y
     pd.DataFrame,  # X
     Optional[pd.DataFrame],  # I
@@ -26,10 +26,10 @@ def model_matrix_fixest(
     np.ndarray,  # na_index
     np.ndarray,  # fe_na
     str,  # na_index_str
-    Optional[List[str]],  # z_names
+    Optional[list[str]],  # z_names
     Optional[str],  # weights
     bool,  # has_weights,
-    Optional[List[str]],  # icovars (list of variables interacted with i() syntax)
+    Optional[list[str]],  # icovars (list of variables interacted with i() syntax)
 ]:
     """
     Create model matrices for fixed effects estimation.
@@ -75,13 +75,13 @@ def model_matrix_fixest(
             An array with indices of dropped columns due to fixed effect singletons or NaNs in the fixed effects.
         - na_index_str : str
             na_index, but as a comma-separated string. Used for caching of demeaned variables.
-        - z_names : Optional[List[str]]
+        - z_names : Optional[list[str]]
             Names of all covariates, minus the endogenous variables, plus the instruments. None if no IV.
         - weights : Optional[str]
             Weights as a string if provided, or None if no weights, e.g., "weights".
         - has_weights : bool
             A boolean indicating whether weights are used.
-        - icovars : Optional[List[str]]
+        - icovars : Optional[list[str]]
             A list of interaction variables provided via `i()`. None if no interaction variables via `i()` provided.
 
     Attributes
@@ -192,9 +192,9 @@ def model_matrix_fixest(
     else:
         endogvar, Z = None, None
 
-    Y, X, endogvar, Z = [
+    Y, X, endogvar, Z = (
         pd.DataFrame(x) if x is not None else x for x in [Y, X, endogvar, Z]
-    ]
+    )
 
     # check if Y, endogvar have dimension (N, 1) - else they are non-numeric
     if Y.shape[1] > 1:
@@ -383,7 +383,7 @@ def _check_is_iv(fml):
     return _is_iv
 
 
-def _clean_fe(data: pd.DataFrame, fval: str) -> Tuple[pd.DataFrame, List[int]]:
+def _clean_fe(data: pd.DataFrame, fval: str) -> tuple[pd.DataFrame, list[int]]:
     """
     Clean and transform fixed effects in a DataFrame.
 
@@ -400,11 +400,11 @@ def _clean_fe(data: pd.DataFrame, fval: str) -> Tuple[pd.DataFrame, List[int]]:
 
     Returns
     -------
-    Tuple[pd.DataFrame, List[int]]
+    tuple[pd.DataFrame, list[int]]
         A tuple containing two items:
         - fe (pd.DataFrame): The DataFrame with cleaned fixed effects. NaNs are
         present in this DataFrame.
-        - fe_na (List[int]): A list of columns in 'fe' that contain NaN values.
+        - fe_na (list[int]): A list of columns in 'fe' that contain NaN values.
     """
 
     fval_list = fval.split("+")
@@ -435,7 +435,7 @@ def _clean_fe(data: pd.DataFrame, fval: str) -> Tuple[pd.DataFrame, List[int]]:
     return fe, fe_na
 
 
-def _get_icovars(_ivars: List[str], X: pd.DataFrame) -> Optional[List[str]]:
+def _get_icovars(_ivars: list[str], X: pd.DataFrame) -> Optional[list[str]]:
     """
     Get all interacted variables via i() syntax. Required for plotting of all interacted variables via iplot().
 

--- a/pyfixest/model_matrix_fixest.py
+++ b/pyfixest/model_matrix_fixest.py
@@ -1,6 +1,6 @@
 import re
 import warnings
-from typing import Optional, Union, list, tuple
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd

--- a/pyfixest/model_matrix_fixest.py
+++ b/pyfixest/model_matrix_fixest.py
@@ -153,9 +153,9 @@ def model_matrix_fixest(
         fml_iv = None
 
     if _is_iv:
-        endogvar, instruments = fml_iv.split("~")
+        endogvar, _ = fml_iv.split("~")
     else:
-        endogvar, instruments = None, None
+        endogvar, _ = None, None
 
     # step 2: create formulas
     fml_exog = f"{depvar}~{covar}"
@@ -301,7 +301,7 @@ def model_matrix_fixest(
             dropped_singleton_bool = detect_singletons(fe.to_numpy())
             keep_singleton_indices = np.where(~dropped_singleton_bool)[0]
 
-            if np.any(dropped_singleton_bool == True):
+            if np.any(dropped_singleton_bool):
                 warnings.warn(
                     f"{np.sum(dropped_singleton_bool)} singleton fixed effect(s) detected. These observations are dropped from the model."
                 )

--- a/pyfixest/model_matrix_fixest.py
+++ b/pyfixest/model_matrix_fixest.py
@@ -1,12 +1,13 @@
 import re
 import warnings
-import pandas as pd
-import numpy as np
+from typing import List, Optional, Tuple, Union
 
+import numpy as np
+import pandas as pd
 from formulaic import model_matrix
-from typing import Optional, Tuple, List, Union
-from pyfixest.exceptions import InvalidReferenceLevelError
+
 from pyfixest.detect_singletons import detect_singletons
+from pyfixest.exceptions import InvalidReferenceLevelError
 
 
 def model_matrix_fixest(

--- a/pyfixest/multcomp.py
+++ b/pyfixest/multcomp.py
@@ -1,10 +1,11 @@
+from typing import List, Union
+
 import numpy as np
 import pandas as pd
-from typing import Union, List
-from pyfixest.summarize import _post_processing_input_checks
-from pyfixest.feols import Feols
-from pyfixest.FixestMulti import FixestMulti
 from tqdm import tqdm
+
+from pyfixest.feols import Feols
+from pyfixest.summarize import _post_processing_input_checks
 
 
 def rwolf(

--- a/pyfixest/multcomp.py
+++ b/pyfixest/multcomp.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import Union, list
 
 import numpy as np
 import pandas as pd
@@ -9,7 +9,7 @@ from pyfixest.summarize import _post_processing_input_checks
 
 
 def rwolf(
-    models: Union[List[Feols], Feols], param: str, B: int, seed: int
+    models: Union[list[Feols], Feols], param: str, B: int, seed: int
 ) -> pd.DataFrame:
     """
     Compute Romano-Wolf adjusted p-values for multiple hypothesis testing.
@@ -20,7 +20,7 @@ def rwolf(
 
     Parameters
     ----------
-    models : List[Feols] or FixestMulti
+    models : list[Feols] or FixestMulti
         A list of models for which the p-values should be computed, or a FixestMulti object.
         Models of type `Feiv` or `Fepois` are not supported.
     param : str

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, Union, list
+from typing import Optional, Union
 
 import numpy as np
 import pandas as pd

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -1,12 +1,13 @@
-from pyfixest.feols import Feols
-from pyfixest.fepois import Fepois
-from pyfixest.feiv import Feiv
+import re
+from typing import List, Optional, Union
 
 import numpy as np
 import pandas as pd
-from typing import Union, List, Optional
 from tabulate import tabulate
-import re
+
+from pyfixest.feiv import Feiv
+from pyfixest.feols import Feols
+from pyfixest.fepois import Fepois
 
 
 def etable(
@@ -362,7 +363,7 @@ def _parse_coef_fmt(coef_fmt: str):
     - coef_fmt_title (str): The title for the coef_fmt string.
     """
 
-    allowed_elements = ["b", "se", "t", "p", " ", "\(", "\)", "\[", "\]", "\n"]
+    allowed_elements = ["b", "se", "t", "p", " ", r"\(", r"\)", r"\[", r"\]", "\n"]
     coef_fmt_elements = re.findall("|".join(allowed_elements), coef_fmt)
     title_map = {
         "b": "Coefficient",

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -1,5 +1,5 @@
 import re
-from typing import List, Optional, Union
+from typing import Optional, Union, list
 
 import numpy as np
 import pandas as pd
@@ -11,10 +11,10 @@ from pyfixest.fepois import Fepois
 
 
 def etable(
-    models: Union[Feols, Fepois, Feiv, List],
+    models: Union[Feols, Fepois, Feiv, list],
     digits: Optional[int] = 3,
     type: Optional[str] = "md",
-    signif_code: Optional[List] = [0.001, 0.01, 0.05],
+    signif_code: Optional[list] = [0.001, 0.01, 0.05],
     coef_fmt: Optional[str] = "b (se)",
 ) -> Union[pd.DataFrame, str]:
     """
@@ -185,7 +185,7 @@ def etable(
 
 
 def summary(
-    models: Union[Feols, Fepois, Feiv, List], digits: Optional[int] = 3
+    models: Union[Feols, Fepois, Feiv, list], digits: Optional[int] = 3
 ) -> None:
     """
     Prints a summary of estimation results for each estimated model.

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -69,7 +69,6 @@ def etable(
     n_coefs = []
     se_type_list = []
     r2_list = []
-    r2_within_list = []
 
     for i, model in enumerate(models):
         dep_var_list.append(model._depvar)

--- a/pyfixest/utils.py
+++ b/pyfixest/utils.py
@@ -165,7 +165,7 @@ def get_data(N=1000, seed=1234, beta_type="1", error_type="1", model="Feols"):
     else:
         raise ValueError("model needs to be 'Feols' or 'Fepois'.")
 
-    Y, Y2 = [pd.Series(x.flatten()) for x in [Y, Y2]]
+    Y, Y2 = (pd.Series(x.flatten()) for x in [Y, Y2])
     Y.name, Y2.name = "Y", "Y2"
 
     cluster = rng.choice(list(range(0, G)), N)

--- a/pyfixest/utils.py
+++ b/pyfixest/utils.py
@@ -62,7 +62,7 @@ def get_ssc(ssc_dict, N, k, G, vcov_sign, vcov_type, is_twoway=False):
     """
 
     adj = ssc_dict["adj"]
-    fixef_k = ssc_dict["fixef_k"]
+    # fixef_k = ssc_dict["fixef_k"] TODO: use fixef_k for ssc
     cluster_adj = ssc_dict["cluster_adj"]
     cluster_df = ssc_dict["cluster_df"]
 

--- a/pyfixest/utils.py
+++ b/pyfixest/utils.py
@@ -1,8 +1,7 @@
+
 import numpy as np
 import pandas as pd
 from formulaic import model_matrix
-import sys
-import time
 
 
 def ssc(adj=True, fixef_k="none", cluster_adj=True, cluster_df="min"):

--- a/pyfixest/visualize.py
+++ b/pyfixest/visualize.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union, list, tuple
 
 import pandas as pd
 from lets_plot import (
@@ -117,13 +117,13 @@ def iplot(
 
 
 def coefplot(
-    models: List,
+    models: list,
     alpha: int = 0.05,
     figsize: tuple = (500, 300),
     yintercept: float = 0,
     xintercept: float = None,
     rotate_xticks: int = 0,
-    coefficients: Optional[List[str]] = None,
+    coefficients: Optional[list[str]] = None,
     title: Optional[str] = None,
     coord_flip: Optional[bool] = True,
 ):
@@ -203,7 +203,7 @@ def coefplot(
 
 def _coefplot(
     df: pd.DataFrame,
-    figsize: Tuple[int, int],
+    figsize: tuple[int, int],
     alpha: float,
     yintercept: Optional[int] = None,
     xintercept: Optional[int] = None,

--- a/pyfixest/visualize.py
+++ b/pyfixest/visualize.py
@@ -1,23 +1,24 @@
+from typing import List, Optional, Tuple, Union
+
 import pandas as pd
-from typing import List, Tuple, Optional
-from pyfixest.summarize import _post_processing_input_checks
-from typing import Union
+from lets_plot import *
 from lets_plot import (
-    ggplot,
     aes,
-    geom_point,
+    coord_flip,
+    element_text,
     geom_errorbar,
     geom_hline,
+    geom_point,
     geom_vline,
+    ggplot,
     ggsize,
-    theme,
-    element_text,
-    position_dodge,
-    coord_flip,
     ggtitle,
+    position_dodge,
+    theme,
     ylab,
 )
-from lets_plot import *
+
+from pyfixest.summarize import _post_processing_input_checks
 
 LetsPlot.setup_html()
 

--- a/pyfixest/visualize.py
+++ b/pyfixest/visualize.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union, list, tuple
+from typing import Optional, Union
 
 import pandas as pd
 from lets_plot import (

--- a/pyfixest/visualize.py
+++ b/pyfixest/visualize.py
@@ -1,8 +1,8 @@
 from typing import List, Optional, Tuple, Union
 
 import pandas as pd
-from lets_plot import *
 from lets_plot import (
+    LetsPlot,
     aes,
     coord_flip,
     element_text,
@@ -99,7 +99,6 @@ def iplot(
     all_icovars = list(set(all_icovars))
 
     df = pd.concat(df_all, axis=0)
-    fml_list = df.index.unique()
     # keep only coefficients interacted via the i() syntax
     df = df[df.Coefficient.isin(all_icovars)].reset_index()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ select = [
   "W", # pycodestyle warnings
   "I", # isort
 #  "D", # flake8-docstrings
-#  "UP", # pyupgrade
+  "UP", # pyupgrade
 #  "SIM", # flake8-simplify
 #  "TRY", # tryceratops
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ select = [
   "I", # isort
 #  "D", # flake8-docstrings
   "UP", # pyupgrade
-#  "SIM", # flake8-simplify
+  "SIM", # flake8-simplify
 #  "TRY", # tryceratops
 
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,50 @@ filterwarnings =[
     "ignore::DeprecationWarning:rpy2"
 ]
 
+[tool.ruff]
+line-length = 88
+fix = true
+extend-include = ["*.ipynb"]
+
+# Assume Python 3.9
+target-version = "py39"
+
+[tool.ruff.lint]
+# docs: https://docs.astral.sh/ruff/rules/
+select = [
+  "F", # Pyflakes
+  "E", # pycodestyle errors
+  "W", # pycodestyle warnings
+  "I", # isort
+#  "D", # flake8-docstrings
+#  "UP", # pyupgrade
+#  "SIM", # flake8-simplify
+#  "TRY", # tryceratops
+
+]
+
+ignore = [
+# do not enable if formatting
+# docs: https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "W191",   # tab indentation
+  "E111",   # indentation
+  "E114",   # indentation
+  "E117",   # over indented
+  "D206",   # indent with spaces
+  "D300",   # triple single quotes
+  "E501",   # line length regulated by formatter
+  "D105",   # missing docstring in magic method
+  "D100",   # missing docstring in public module
+  "D104",   # missing docstring in public package
+  "TRY003", # Avoid specifying long messages outside the exception class
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.format]
+docstring-code-format = true
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_demean.py
+++ b/tests/test_demean.py
@@ -1,6 +1,6 @@
-import pytest
 import numpy as np
 import pyhdfe
+
 from pyfixest.demean import demean
 
 

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -1,13 +1,14 @@
-from pyfixest.did.estimation import did2s as did2s_pyfixest
-from pyfixest.did.estimation import lpdid, event_study
-import pandas as pd
 import numpy as np
+import pandas as pd
 import pytest
+import rpy2.robjects as ro
+from rpy2.robjects import pandas2ri
 
 # rpy2 imports
 from rpy2.robjects.packages import importr
-import rpy2.robjects as ro
-from rpy2.robjects import pandas2ri
+
+from pyfixest.did.estimation import did2s as did2s_pyfixest
+from pyfixest.did.estimation import event_study, lpdid
 
 pandas2ri.activate()
 did2s = importr("did2s")

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -186,7 +186,7 @@ def test_errors():
     # boolean strings cannot be converted
     df_het["treat"] = df_het["treat"].astype(str)
     with pytest.raises(ValueError):
-        fit = did2s_pyfixest(
+        did2s_pyfixest(
             df_het,
             yname="dep_var",
             first_stage="~ X | state + year",
@@ -198,7 +198,7 @@ def test_errors():
 
     df_het["treat2"] = np.random.choice([0, 1, 2], size=len(df_het))
     with pytest.raises(ValueError):
-        fit = did2s_pyfixest(
+        did2s_pyfixest(
             df_het,
             yname="dep_var",
             first_stage="~ X | state + year",

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -185,7 +185,7 @@ def test_errors():
 
     # boolean strings cannot be converted
     df_het["treat"] = df_het["treat"].astype(str)
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         did2s_pyfixest(
             df_het,
             yname="dep_var",

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -155,7 +155,7 @@ def test_i_interaction_errors():
 def test_all_variables_multicollinear():
     data = get_data()
     with pytest.raises(ValueError):
-        fit = feols("Y ~ f1 | f1", data=data)
+        feols("Y ~ f1 | f1", data=data)
 
 
 def test_wls_errors():

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,23 +1,22 @@
-from typing import Type
-import pytest
 import numpy as np
 import pandas as pd
-from pyfixest.utils import get_data
+import pytest
+
+from pyfixest.estimation import feols, fepois
 from pyfixest.exceptions import (
     DuplicateKeyError,
     EndogVarsAsCovarsError,
     InstrumentsAsCovarsError,
-    UnderDeterminedIVError,
-    VcovTypeNotSupportedError,
+    InvalidReferenceLevelError,
     MultiEstNotSupportedError,
     NanInClusterVarError,
-    InvalidReferenceLevelError,
+    UnderDeterminedIVError,
+    VcovTypeNotSupportedError,
 )
-from pyfixest.estimation import feols, fepois
 from pyfixest.FormulaParser import FixestFormulaParser
 from pyfixest.multcomp import rwolf
 from pyfixest.summarize import etable, summary
-from pyfixest.summarize import etable
+from pyfixest.utils import get_data
 
 
 def test_formula_parser2():

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -1,5 +1,4 @@
-import pytest
-from pyfixest.FormulaParser import _unpack_fml, _pack_to_fml, _find_sw, _flatten_list
+from pyfixest.FormulaParser import _find_sw, _flatten_list, _pack_to_fml, _unpack_fml
 
 
 def test_unpack_fml():

--- a/tests/test_i.py
+++ b/tests/test_i.py
@@ -1,13 +1,14 @@
-import pytest
 import numpy as np
 import pandas as pd
-from pyfixest.estimation import feols
-from pyfixest.exceptions import InvalidReferenceLevelError
+import pytest
+import rpy2.robjects as ro
+from rpy2.robjects import pandas2ri
 
 # rpy2 imports
 from rpy2.robjects.packages import importr
-import rpy2.robjects as ro
-from rpy2.robjects import pandas2ri
+
+from pyfixest.estimation import feols
+from pyfixest.exceptions import InvalidReferenceLevelError
 
 pandas2ri.activate()
 

--- a/tests/test_multcomp.py
+++ b/tests/test_multcomp.py
@@ -1,12 +1,12 @@
-from pyfixest.estimation import feols
-from pyfixest.utils import get_data
-from pyfixest.multcomp import rwolf, _get_rwolf_pval
 import numpy as np
 import pandas as pd
-
-from rpy2.robjects.packages import importr
 import rpy2.robjects as ro
 from rpy2.robjects import pandas2ri
+from rpy2.robjects.packages import importr
+
+from pyfixest.estimation import feols
+from pyfixest.multcomp import _get_rwolf_pval, rwolf
+from pyfixest.utils import get_data
 
 pandas2ri.activate()
 

--- a/tests/test_multicollinearity.py
+++ b/tests/test_multicollinearity.py
@@ -1,6 +1,6 @@
-import pytest
 import numpy as np
 import pandas as pd
+
 from pyfixest.estimation import feols
 
 

--- a/tests/test_others.py
+++ b/tests/test_others.py
@@ -1,8 +1,9 @@
+import numpy as np
+import pandas as pd
+import polars as pl
+
 from pyfixest.estimation import feols, fepois
 from pyfixest.utils import get_data, ssc
-import polars as pl
-import pandas as pd
-import numpy as np
 
 
 def test_multicol_overdetermined_iv():

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -1,8 +1,9 @@
-import pytest
 import pandas as pd
-from pyfixest.utils import get_data
+import pytest
+
 from pyfixest.estimation import feols
-from pyfixest.visualize import iplot, coefplot
+from pyfixest.utils import get_data
+from pyfixest.visualize import coefplot, iplot
 
 
 @pytest.fixture

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -1,6 +1,7 @@
-import pytest
 import numpy as np
 import pandas as pd
+import pytest
+
 from pyfixest.estimation import fepois
 
 

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -20,4 +20,4 @@ def test_separation():
     with pytest.warns(
         UserWarning, match="2 observations removed because of separation."
     ):
-        mod = fepois("Y ~ x  | fe1", data=df, vcov="hetero")
+        fepois("Y ~ x  | fe1", data=df, vcov="hetero")

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -1,14 +1,15 @@
-import pytest
 import numpy as np
 import pandas as pd
-from pyfixest.utils import get_data
-from pyfixest.estimation import feols, fepois
-from pyfixest.exceptions import NotImplementedError
+import pytest
+import rpy2.robjects as ro
+from rpy2.robjects import pandas2ri
 
 # rpy2 imports
 from rpy2.robjects.packages import importr
-import rpy2.robjects as ro
-from rpy2.robjects import pandas2ri
+
+from pyfixest.estimation import feols, fepois
+from pyfixest.exceptions import NotImplementedError
+from pyfixest.utils import get_data
 
 pandas2ri.activate()
 

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 
-from pyfixest.estimation import feols
+from pyfixest.estimation import feols, fepois
 from pyfixest.utils import get_data, ssc
 
 
@@ -98,14 +98,14 @@ def test_CRV3_fixef(N, seed, beta_type, error_type):
 
 def run_crv3_poisson():
     data = get_data(N=1000, seed=1234, beta_type="1", error_type="1", model="Fepois")
-    fit = fepois(
+    fepois(
         fml="Y~X1 + C(f2)",
         data=data,
         vcov={"CRV3": "f1"},
         ssc=ssc(adj=False, cluster_adj=False),
     )
 
-    fit = fepois(
+    fepois(
         fml="Y~X1 |f1 + f2",
         data=data,
         vcov={"CRV3": "f1"},

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -1,8 +1,8 @@
-import pytest
 import numpy as np
-from pyfixest.utils import ssc
-from pyfixest.utils import get_data
+import pytest
+
 from pyfixest.estimation import feols
+from pyfixest.utils import get_data, ssc
 
 
 @pytest.mark.parametrize("seed", [3212, 3213, 3214])

--- a/tests/test_ssc.py
+++ b/tests/test_ssc.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pyfixest.utils import get_ssc
 
 

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -1,6 +1,6 @@
 from pyfixest.estimation import feols, fepois
+from pyfixest.summarize import etable, summary
 from pyfixest.utils import get_data
-from pyfixest.summarize import summary, etable
 
 
 def test_summary():

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -482,7 +482,7 @@ def test_multi_fit(N, seed, beta_type, error_type, dropna, fml_multi):
         py_se = mod.se().values
 
         # sort py_coef, py_se
-        py_coef, py_se = [np.sort(x) for x in [py_coef, py_se]]
+        py_coef, py_se = (np.sort(x) for x in [py_coef, py_se])
 
         fixest_object = r_fixest.rx2(x + 1)
         fixest_coef = fixest_object.rx2("coefficients")
@@ -492,7 +492,7 @@ def test_multi_fit(N, seed, beta_type, error_type, dropna, fml_multi):
         # fixest_se = fixest.se(r_fixest)
 
         # sort fixest_coef, fixest_se
-        fixest_coef, fixest_se = [np.sort(x) for x in [fixest_coef, fixest_se]]
+        fixest_coef, fixest_se = (np.sort(x) for x in [fixest_coef, fixest_se])
 
         np.testing.assert_allclose(
             py_coef, fixest_coef, rtol=rtol, atol=atol, err_msg="Coefs are not equal."

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -194,17 +194,12 @@ def test_single_fit(
         #    return pytest.skip("Poisson does not support iid inference")
 
         if iv_check._is_iv:
-            is_iv = True
             run_test = False
         else:
-            is_iv = False
             run_test = True
 
             # if formula does not contain "i(" or "C(", add, separation:
             if "i(" not in fml and "C(" not in fml:
-                where_zeros = np.where(data["Y"] == 0)[
-                    0
-                ]  # because np.where evaluates to a tuple
                 # draw three random indices
                 # idx = rng.choice(where_zeros, 3, True)
                 idx = np.array([10, 11, 12])
@@ -266,7 +261,6 @@ def test_single_fit(
         py_tstat = mod.tstat().xs("X1")
         py_confint = mod.confint().xs("X1").values
         py_nobs = mod._N
-        py_resid = mod._u_hat.flatten()
         # TODO: test residuals
 
         fixest_df = broom.tidy_fixest(r_fixest, conf_int=ro.BoolVector([True]))
@@ -292,7 +286,6 @@ def test_single_fit(
         r_tstat = df_X1["statistic"]
         r_confint = df_X1[["conf.low", "conf.high"]].values.astype(np.float64)
         r_nobs = stats.nobs(r_fixest)
-        r_resid = r_fixest.rx2("working_residuals")
 
         np.testing.assert_allclose(
             py_coef, r_coef, rtol=rtol, atol=atol, err_msg="py_coef != r_coef"
@@ -521,12 +514,6 @@ def test_twoway_clustering():
                 "Y ~ X1 + X2 ",
                 data=data,
                 vcov={"CRV1": "f1 +f2"},
-                ssc=ssc(cluster_adj=cluster_adj, cluster_df=cluster_df),
-            )
-            fit2 = feols(
-                "Y ~ X1 + X2 ",
-                data=data,
-                vcov={"CRV3": " f1+f2"},
                 ssc=ssc(cluster_adj=cluster_adj, cluster_df=cluster_df),
             )
 
@@ -782,7 +769,7 @@ def test_wald_test(fml, data):
 
     wald_r = fixest.wald(fit_r)
     wald_stat_r = wald_r[0]
-    wald_pval_r = wald_r[1]
+    #wald_pval_r = wald_r[1]
 
     np.testing.assert_allclose(fit1._f_statistic, wald_stat_r)
     # np.testing.assert_allclose(fit1._f_statistic_pvalue, wald_pval_r)
@@ -830,8 +817,8 @@ def test_singleton_dropping():
     )
 
     # test that standard errors match
-    se_py = fit_py.se().values
-    se_r = fixest.se(fit_r)
+    # se_py = fit_py.se().values
+    # se_r = fixest.se(fit_r)
     # np.testing.assert_allclose(
     #    se_py, se_r, rtol=1e-04, atol=1e-04, err_msg="Standard errors do not match."
     # )

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -1,16 +1,18 @@
-import pytest
 import re
 import warnings
+
 import numpy as np
 import pandas as pd
-from pyfixest.estimation import feols, fepois
-from pyfixest.utils import get_data, ssc
-from pyfixest.exceptions import NotImplementedError
+import pytest
+import rpy2.robjects as ro
+from rpy2.robjects import pandas2ri
 
 # rpy2 imports
 from rpy2.robjects.packages import importr
-import rpy2.robjects as ro
-from rpy2.robjects import pandas2ri
+
+from pyfixest.estimation import feols, fepois
+from pyfixest.exceptions import NotImplementedError
+from pyfixest.utils import get_data, ssc
 
 pandas2ri.activate()
 

--- a/tests/test_wald_test.py
+++ b/tests/test_wald_test.py
@@ -1,12 +1,13 @@
-import pytest
 import numpy as np
 import pandas as pd
-from pyfixest.estimation import feols
-from pyfixest.utils import ssc
+import pytest
+from rpy2.robjects import pandas2ri
 
 # rpy2 imports
 from rpy2.robjects.packages import importr
-from rpy2.robjects import pandas2ri
+
+from pyfixest.estimation import feols
+from pyfixest.utils import ssc
 
 pandas2ri.activate()
 clubSandwich = importr("clubSandwich")

--- a/tests/test_wildboottest.py
+++ b/tests/test_wildboottest.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from pyfixest.estimation import feols
 from pyfixest.utils import get_data, ssc
 


### PR DESCRIPTION
Some suggestions for enabling linting and formatting with ruff. Covers Issue #296 

## Summary:
- I recommend adding ruff as the linter and formatting for Python code. It's fast and provides a comprehensive set of rules. It can be a plug-in replacement for black. 
- strongly recommend enabling pyflakes, errors, warnings, and isort linting ("F", "E", "W", "I" rule sets)
- recommend docstyle linting and formatting, but that may require a side project to standardize documentation (I'm happy to volunteer to assist with that project) ("D" rule set)
- consider adding ruff rules for upgrading and simplifying code ("UP", "SIM", "TRY" rule sets)
- To implement whatever rules that you decide on, it could be done in one of two ways:
   a. run `poetry run pre-commit run ruff --all-files` and work through all of the unfixed linting errors at once
   b. run the ruff pre-commit hook per file, either upfront or as revisions are made to each file
- Once the linting rules are enabled and files fixed, it would be a good idea to set up a workflow that runs ruff on any push to GitHub, could be a github workflow or use pre-commit ci (https://pre-commit.ci/)

## Changes:
- I've added to the .pre-commit-config.yaml the `ruff` pre-commit hook that will enforce linting and formatting rules
- I've added rules for linting and formatting with ruff
- Formatting is set to be a replacement for `black`, thus you could swap this out for the `black` github workflow see Ruff formatted reference: https://docs.astral.sh/ruff/formatter/
- Docstyle formatting is not turned on, would need to remove the comment `#` on the ruff "D" linting rules. however, if enables (which I recommend below) the docstyle is set to `numpy`. could use numpy, google, or pep257 https://docs.astral.sh/ruff/settings/#lintpydocstyle

### Base linting rules
*I recommend, at a minimum, enabling the "F" (pyflakes), "E" (pycodestyle errors), "W" (pycodestyle warnings), and "I" (isort) rule set.*

If you implement all of the four rule sets (and some of the ruff.ignore exceptions included in the pyproject.toml, `poetry run pre-commit run ruff --all-files` returns 94 errors. 57 can be automatically fixed with 37 remaining that cannot be autofixed.

Ruff returns:
"F", "E", "W", "I": 94 errors (57 fixed, 37 remaining)

### docstyle

I also think it would be a good idea to enforce the "D" rule set for lining docstrings. This will help to ensure the docstrings that are used for the quartodocs documentation page are consistent. However, the docstring linting is likely to be fairly tedious on the first big push. You've written a lot of really amazing documentation. Formatting all of it might require a bit of an effort. It's actually one that I'm excited to take on as this is likely where I can best allocate my time in the near term.

Ruff returns:
"D": 416 errors (225 fixed, 191 remaining)

### Nice to have linting rules

Additional rules that would be "nice to have", but might require heavier refactoring:
- "UP" (Upgrade python version syntax to 3.9+): 73 errors (8 fixed, 65 remaining)
- "SIM" (pycodestyle simplify): 40 errors (1 fixed, 39 remaining)
- "TRY" (exceptions): 14 errors (0 fixed, 14 remaining)