### PR TITLE
Docstyle formatting

### DIFF
--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -34,7 +34,9 @@ website:
 
 quartodoc:
   package: pyfixest
-
+  title: "PyFixest Function Reference"
+  parser: numpy
+  rewrite_all_pages: False
   sidebar: _sidebar.yml
 
   sections:

--- a/docs/_sidebar.yml
+++ b/docs/_sidebar.yml
@@ -8,6 +8,8 @@ website:
       - reference/did.estimation.did2s.qmd
       - reference/did.estimation.lpdid.qmd
       - reference/did.estimation.event_study.qmd
+      - reference/multcomp.bonferroni.qmd
+      - reference/multcomp.rwolf.qmd
       section: Estimation Functions
     - contents:
       - reference/feols.Feols.qmd

--- a/pyfixest/FixestMulti.py
+++ b/pyfixest/FixestMulti.py
@@ -16,18 +16,16 @@ from pyfixest.visualize import coefplot, iplot
 
 
 class FixestMulti:
-    """
-    # FixestMulti:
-
-    A class to estimate multiple regression models with fixed effects.
-    """
+    """A class to estimate multiple regression models with fixed effects."""
 
     def __init__(self, data: pd.DataFrame) -> None:
         """
         Initialize a class for multiple fixed effect estimations.
 
-        Args:
-            data (pd.DataFrame): The input DataFrame for the object.
+        Parameters
+        ----------
+        data : panda.DataFrame
+            The input DataFrame for the object.
 
         Returns
         -------
@@ -57,20 +55,40 @@ class FixestMulti:
         i_ref2: Optional[Union[list, str]] = None,
     ) -> None:
         """
-        Utility function to prepare estimation via the `feols()` or `fepois()` methods. The function is called by both methods.
-        Mostly deparses the fml string.
+        Prepare model for estimation.
 
-        Args:
-            estimation (str): Type of estimation. Either "feols" or "fepois".
-            fml (str): A three-sided formula string using fixest formula syntax. Supported syntax includes: see `feols()` or `fepois()`.
-            vcov (Union[None, str, dict[str, str]], optional): A string or dictionary specifying the type of variance-covariance matrix to use for inference. See `feols()` or `fepois()`.
-            weights (Union[None, np.ndarray], optional): An array of weights. Either None or a 1D array of length N. Default is None.
-            ssc (dict[str, str], optional): A dictionary specifying the type of standard errors to use for inference. See `feols()` or `fepois()`.
-            fixef_rm (str, optional): A string specifying whether singleton fixed effects should be dropped.
-                Options are "none" (default) and "singleton". If "singleton", singleton fixed effects are dropped.
-            drop_intercept (bool, optional): Whether to drop the intercept. Default is False.
-            i_ref1 (Optional[Union[list, str]], optional): A list or string specifying the reference category for the first interaction variable.
-            i_ref2 (Optional[Union[list, str]], optional): A list or string specifying the reference category for the second interaction variable.
+        Utility function to prepare estimation via the `feols()` or `fepois()` methods.
+        The function is called by both methods. Mostly deparses the fml string.
+
+        Parameters
+        ----------
+        estimation : str
+            Type of estimation. Either "feols" or "fepois".
+        fml : str
+            A three-sided formula string using fixest formula syntax.
+            Supported syntax includes: see `feols()` or `fepois()`.
+        vcov : Union[None, str, dict[str, str]], optional
+            A string or dictionary specifying the type of variance-covariance
+            matrix to use for inference.
+            See `feols()` or `fepois()`.
+        weights : Union[None, np.ndarray], optional
+            An array of weights.
+            Either None or a 1D array of length N. Default is None.
+        ssc : dict[str, str], optional
+            A dictionary specifying the type of standard errors to use for inference.
+            See `feols()` or `fepois()`.
+        fixef_rm : str, optional
+            A string specifying whether singleton fixed effects should be dropped.
+            Options are "none" (default) and "singleton". If "singleton",
+            singleton fixed effects are dropped.
+        drop_intercept : bool, optional
+            Whether to drop the intercept. Default is False.
+        i_ref1 : Optional[Union[list, str]], optional
+            A list or string specifying the reference category for the first
+            interaction variable.
+        i_ref2 : Optional[Union[list, str]], optional
+            A list or string specifying the reference category for the second
+            interaction variable.
 
         Returns
         -------
@@ -130,18 +148,24 @@ class FixestMulti:
         """
         Estimate multiple regression models.
 
-        Args:
-            vcov (Union[str, dict[str, str]]): A string or dictionary specifying the type of variance-covariance
-                matrix to use for inference.
-                - If a string, can be one of "iid", "hetero", "HC1", "HC2", "HC3".
-                - If a dictionary, it should have the format {"CRV1": "clustervar"} for CRV1 inference
-                  or {"CRV3": "clustervar"} for CRV3 inference.
-            fixef_keys (list[str]): A list of fixed effects combinations.
-            collin_tol (float, optional): The tolerance level for the multicollinearity check. Default is 1e-6.
-            iwls_maxiter (int, optional): The maximum number of iterations for the IWLS algorithm. Default is 25.
-                Only relevant for non-linear estimation strategies.
-            iwls_tol (float, optional): The tolerance level for the IWLS algorithm. Default is 1e-8.
-                Only relevant for non-linear estimation strategies.
+        Parameters
+        ----------
+        vcov : Union[str, dict[str, str]]
+            A string or dictionary specifying the type of variance-covariance
+            matrix to use for inference.
+            - If a string, can be one of "iid", "hetero", "HC1", "HC2", "HC3".
+            - If a dictionary, it should have the format {"CRV1": "clustervar"}
+            for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
+        fixef_keys : list[str]
+            A list of fixed effects combinations.
+        collin_tol : float, optional
+            The tolerance level for the multicollinearity check. Default is 1e-6.
+        iwls_maxiter : int, optional
+            The maximum number of iterations for the IWLS algorithm. Default is 25.
+            Only relevant for non-linear estimation strategies.
+        iwls_tol : float, optional
+            The tolerance level for the IWLS algorithm. Default is 1e-8.
+            Only relevant for non-linear estimation strategies.
 
         Returns
         -------
@@ -267,7 +291,8 @@ class FixestMulti:
                                 weights_name=_weights,
                             )
 
-                        # special case: sometimes it is useful to fit models as "Y ~ 0 | f1 + f2" to demean Y and to use the predict() method
+                        # special case: sometimes it is useful to fit models as
+                        # "Y ~ 0 | f1 + f2" to demean Y and to use the predict() method
                         if FIT._X_is_empty:
                             FIT._u_hat = Y.to_numpy() - Yd
                         else:
@@ -337,7 +362,7 @@ class FixestMulti:
                         na_index=na_index,
                     )
 
-                    # if X is empty: no inference (empty X only as shorthand for demeaning)
+                    # if X is empty: no inference (empty X only as shorthand for demeaning)  # noqa: W505
                     if not FIT._X_is_empty:
                         # inference
                         vcov_type = _get_vcov_type(vcov, fval)
@@ -361,6 +386,7 @@ class FixestMulti:
     def set_fixest_multi_flag(self):
         """
         Set a flag to indicate whether multiple estimations are being performed or not.
+
         Simple check if `all_fitted_models` has more than one key.
         Throws an error if multiple estimations are being performed with IV estimation.
         Args:
@@ -373,17 +399,22 @@ class FixestMulti:
             if self._is_iv:
                 raise MultiEstNotSupportedError(
                     """
-                        Multiple Estimations is currently not supported with IV.
-                        This is mostly due to insufficient testing and will be possible with a future release of PyFixest.
-                        """
+                    Multiple Estimations is currently not supported with IV.
+                    This is mostly due to insufficient testing and will be possible
+                    with a future release of PyFixest.
+                    """
                 )
 
     def to_list(self):
         """
-        Returns a list of all fitted models.
-        Args:
+        Return a list of all fitted models.
+
+        Parameters
+        ----------
             None
-        Returns:
+
+        Returns
+        -------
             A list of all fitted models of types Feols or Fepois.
         """
         return list(self.all_fitted_models.values())
@@ -393,18 +424,21 @@ class FixestMulti:
         Update regression inference "on the fly".
 
         By calling vcov() on a "Fixest" object, all inference procedures applied
-        to the "Fixest" object are replaced with the variance-covariance matrix specified via the method.
+        to the "Fixest" object are replaced with the variance-covariance matrix
+        specified via the method.
 
-        Args:
-            vcov (Union[str, dict[str, str]]): A string or dictionary specifying the type of variance-covariance
-                matrix to use for inference.
-                - If a string, can be one of "iid", "hetero", "HC1", "HC2", "HC3".
-                - If a dictionary, it should have the format {"CRV1": "clustervar"} for CRV1 inference
-                  or {"CRV3": "clustervar"} for CRV3 inference.
+        Parameters
+        ----------
+        vcov : Union[str, dict[str, str]])
+            A string or dictionary specifying the type of variance-covariance
+            matrix to use for inference.
+            - If a string, can be one of "iid", "hetero", "HC1", "HC2", "HC3".
+            - If a dictionary, it should have the format {"CRV1": "clustervar"}
+            for CRV1 inference or {"CRV3": "clustervar"} for CRV3 inference.
 
         Returns
         -------
-            An instance of the "Fixest" class with updated inference.f
+            An instance of the "Fixest" class with updated inference.
         """
         for model in list(self.all_fitted_models.keys()):
             fxst = self.all_fitted_models[model]
@@ -417,11 +451,11 @@ class FixestMulti:
 
     def tidy(self) -> pd.DataFrame:
         """
-        Returns the results of an estimation using `feols()` as a tidy Pandas DataFrame.
+        Return the results of an estimation using `feols()` as a tidy Pandas DataFrame.
 
         Returns
         -------
-            pd.DataFrame or str
+        pandas.DataFrame or str
                 A tidy DataFrame with the following columns:
                 - fml: the formula used to generate the results
                 - Coefficient: the names of the coefficients
@@ -431,8 +465,8 @@ class FixestMulti:
                 - Pr(>|t|): the p-values of the estimated coefficients
                 - 2.5 %: the lower bound of the 95% confidence interval
                 - 97.5 %: the upper bound of the 95% confidence interval
-                If `type` is set to "markdown", the resulting DataFrame will be returned as a
-                markdown-formatted string with three decimal places.
+                If `type` is set to "markdown", the resulting DataFrame will be
+                returned as a markdown-formatted string with three decimal places.
         """
         res = []
         for x in list(self.all_fitted_models.keys()):
@@ -445,12 +479,12 @@ class FixestMulti:
 
         return res
 
-    def summary(self, digits: int = 3) -> None:
+    def summary(self, digits: int = 3) -> None:  # noqa: D102
         for x in list(self.all_fitted_models.keys()):
             fxst = self.all_fitted_models[x]
             fxst.summary(digits=digits)
 
-    def etable(self, digits: int = 3) -> pd.DataFrame:
+    def etable(self, digits: int = 3) -> pd.DataFrame:  # noqa: D102
         return self.tidy().T.round(digits)
 
     def coef(self) -> pd.Series:
@@ -459,7 +493,9 @@ class FixestMulti:
 
         Returns
         -------
-            A pd.Series with coefficient names and Estimates. The key indicates which models the estimated statistic derives from.
+        pandas.Series
+            A pd.Series with coefficient names and Estimates. The key indicates
+            which models the estimated statistic derives from.
         """
         return self.tidy()["Estimate"]
 
@@ -469,7 +505,9 @@ class FixestMulti:
 
         Returns
         -------
-            A pd.Series with coefficient names and standard error estimates. The key indicates which models the estimated statistic derives from.
+        pandas.Series
+            A pd.Series with coefficient names and standard error estimates.
+            The key indicates which models the estimated statistic derives from.
 
         """
         return self.tidy()["Std. Error"]
@@ -480,7 +518,8 @@ class FixestMulti:
 
         Returns
         -------
-            A pd.Series with coefficient names and estimated t-statistics. The key indicates which models the estimated statistic derives from.
+            A pd.Series with coefficient names and estimated t-statistics.
+            The key indicates which models the estimated statistic derives from.
 
         """
         return self.tidy()["t value"]
@@ -491,18 +530,22 @@ class FixestMulti:
 
         Returns
         -------
-            A pd.Series with coefficient names and p-values. The key indicates which models the estimated statistic derives from.
+        pandas.Series
+            A pd.Series with coefficient names and p-values.
+            The key indicates which models the estimated statistic derives from.
 
         """
         return self.tidy()["Pr(>|t|)"]
 
     def confint(self) -> pd.Series:
-        """'
+        """
         Obtain confidence intervals for the fitted models.
 
         Returns
         -------
-            A pd.Series with coefficient names and confidence intervals. The key indicates which models the estimated statistic derives from.
+        pandas.Series
+            A pd.Series with coefficient names and confidence intervals.
+            The key indicates which models the estimated statistic derives from.
         """
         return self.tidy()[["2.5 %", "97.5 %"]]
 
@@ -517,20 +560,33 @@ class FixestMulti:
         coord_flip: Optional[bool] = True,
     ):
         """
-        Plot model coefficients with confidence intervals for variable interactions specified via the `i()` syntax.
+        Plot model coefficients.
 
-        Args:
-            alpha (float, optional): The significance level for the confidence intervals. Default is 0.05.
-            figsize (tuple, optional): The size of the figure. Default is (10, 10).
-            yintercept (Union[int, str, None], optional): The value at which to draw a horizontal line.
-            xintercept (Union[int, str, None], optional): The value at which to draw a vertical line.
-            rotate_xticks (int, optional): The rotation angle for x-axis tick labels. Default is 0.
-            title (str, optional): The title of the plot. Default is None.
-            coord_flip (bool, optional): Whether to flip the coordinates of the plot. Default is True.
+        Plot model coefficients with confidence intervals for variable interactions
+        specified via the `i()` syntax.
+
+        Parameters
+        ----------
+        alpha : float, optional
+            The significance level for the confidence intervals. Default is 0.05.
+        figsize : tuple, optional
+            The size of the figure. Default is (10, 10).
+        yintercept : Union[int, str, None], optional
+            The value at which to draw a horizontal line.
+        xintercept : Union[int, str, None], optional
+            The value at which to draw a vertical line.
+        rotate_xticks : int, optional
+            The rotation angle for x-axis tick labels. Default is 0.
+        title : str, optional
+            The title of the plot. Default is None.
+        coord_flip : bool, optional
+            Whether to flip the coordinates of the plot. Default is True.
 
         Returns
         -------
-            A lets-plot figure of coefficients (and respective CIs) interacted via the `i()` syntax.
+        lets-plot figure
+            A lets-plot figure of coefficients (and respective CIs) interacted
+            via the `i()` syntax.
         """
         models = self.all_fitted_models
         # get a list, not a dict, as iplot only works with lists
@@ -559,18 +615,30 @@ class FixestMulti:
         coord_flip: Optional[bool] = True,
     ):
         """
-        Plot estimation results. The plot() method is only defined for single regressions.
-        Args:
-            alpha (float): the significance level for the confidence intervals. Default is 0.05.
-            figsize (tuple): the size of the figure. Default is (5, 2).
-            yintercept (float): the value of the y-intercept. Default is 0.
-            figtitle (str, optional): The title of the figure. Default is None.
-            figtext (str, optional): The text at the bottom of the figure. Default is None.
-            title (str, optional): The title of the plot. Default is None.
-            coord_flip (bool, optional): Whether to flip the coordinates of the plot. Default is True.
+        Plot estimation results.
+
+        The plot() method is only defined for single regressions.
+
+        Parameters
+        ----------
+        alpha : float
+            The significance level for the confidence intervals. Default is 0.05.
+        figsize : tuple
+            The size of the figure. Default is (5, 2).
+        yintercept : float
+            The value of the y-intercept. Default is 0.
+        figtitle:str, optional
+        The title of the figure. Default is None.
+        figtext : str, optional
+            The text at the bottom of the figure. Default is None.
+        title : str, optional
+            The title of the plot. Default is None.
+        coord_flip : bool, optional
+            Whether to flip the coordinates of the plot. Default is True.
 
         Returns
         -------
+        lets-plot figure
             A lets-plot figure of regression coefficients.
         """
         # get a list, not a dict, as iplot only works with lists
@@ -605,26 +673,37 @@ class FixestMulti:
         """
         Run a wild cluster bootstrap for all regressions in the Fixest object.
 
-        Args:
-            B (int): The number of bootstrap iterations to run.
-            param (Union[str, None], optional): A string of length one, containing the test parameter of interest. Default is None.
-            cluster: Optional[Union[np.ndarray, pd.Series, pd.DataFrame]] = None,
-            weights_type (str, optional): The type of bootstrap weights. Either 'rademacher', 'mammen', 'webb', or 'normal'.
-                Default is 'rademacher'.
-            impose_null (bool, optional): Should the null hypothesis be imposed on the bootstrap dgp, or not?
-                Default is True.
-            bootstrap_type (str, optional): A string of length one. Allows choosing the bootstrap type
-                to be run. Either '11', '31', '13', or '33'. Default is '11'.
-            seed (Union[str, None], optional): Option to provide a random seed. Default is None.
-            adj (bool, optional): Whether to adjust the original coefficients with the bootstrap distribution.
-                Default is True.
-            cluster_adj (bool, optional): Whether to adjust standard errors for clustering in the bootstrap.
-                Default is True.
+        Parameters
+        ----------
+        B : int
+            The number of bootstrap iterations to run.
+        param : Union[str, None], optional
+            A string of length one, containing the test parameter of interest.
+            Default is None.
+        cluster : Optional[Union[np.ndarray, pd.Series, pd.DataFrame]] = None,
+        weights_type : str, optional
+            The type of bootstrap weights. Either 'rademacher', 'mammen', 'webb',
+            or 'normal'. Default is 'rademacher'.
+        impose_null : bool, optional
+            Should the null hypothesis be imposed on the bootstrap dgp, or not?
+            Default is True.
+        bootstrap_type : str, optional
+            A string of length one. Allows choosing the bootstrap type to be run.
+            Either '11', '31', '13', or '33'. Default is '11'.
+        seed : Union[str, None], optional
+            Option to provide a random seed. Default is None.
+        adj:bool, optional
+            Whether to adjust the original coefficients with the bootstrap distribution.
+            Default is True.
+        cluster_adj : bool, optional
+            Whether to adjust standard errors for clustering in the bootstrap.
+            Default is True.
 
         Returns
         -------
-            A pd.DataFrame with bootstrapped t-statistic and p-value. The index indicates which model the estimated
-            statistic derives from.
+        pandas.DataFrame
+            A pd.DataFrame with bootstrapped t-statistic and p-value.
+            The index indicates which model the estimated statistic derives from.
         """
         res = []
         for x in list(self.all_fitted_models.keys()):
@@ -659,10 +738,14 @@ class FixestMulti:
         self, i: Union[int, str], print_fml: Optional[bool] = True
     ) -> Union[Feols, Fepois]:
         """
-        Utility method to fetch a model of class Feols from the Fixest class.
-        Args:
-            i (int or str): The index of the model to fetch.
-            print_fml (bool, optional): Whether to print the formula of the model. Default is True.
+        Fetch a model of class Feols from the Fixest class.
+
+        Parameters
+        ----------
+        i : int or str
+            The index of the model to fetch.
+        print_fml : bool, optional
+            Whether to print the formula of the model. Default is True.
 
         Returns
         -------
@@ -687,16 +770,23 @@ def get_fml(
     """
     Stitches together the formula string for the regression.
 
-    Args:
-        depvar (str): The dependent variable.
-        covar (str): The covariates. E.g. "X1+X2+X3"
-        fval (str): The fixed effects. E.g. "X1+X2". "0" if no fixed effects.
-        endogvars (str, optional): The endogenous variables.
-        instruments (str, optional): The instruments. E.g. "Z1+Z2+Z3"
+    Parameters
+    ----------
+    depvar : str
+        The dependent variable.
+    covar : str
+        The covariates. E.g. "X1+X2+X3"
+    fval : str
+        The fixed effects. E.g. "X1+X2". "0" if no fixed effects.
+    endogvars : str, optional
+        The endogenous variables.
+    instruments : str, optional
+        The instruments. E.g. "Z1+Z2+Z3"
 
     Returns
     -------
-        str: The formula string for the regression.
+    str
+        The formula string for the regression.
     """
     fml = f"{depvar} ~ {covar}"
 
@@ -717,15 +807,23 @@ def get_fml(
 
 def _get_vcov_type(vcov, fval):
     """
-    Passes the specified vcov type. If no vcov type specified, sets the default vcov type as iid if no fixed effect
-    is included in the model, and CRV1 clustered by the first fixed effect if a fixed effect is included in the model.
-    Args:
-        vcov (str): The specified vcov type.
-        fval (str): The specified fixed effects. (i.e. "X1+X2")
+    Pass the specified vcov type.
+
+    Passes the specified vcov type. If no vcov type specified, sets the default
+    vcov type as iid if no fixed effect is included in the model, and CRV1
+    clustered by the first fixed effect if a fixed effect is included in the model.
+
+    Parameters
+    ----------
+    vcov : str
+        The specified vcov type.
+    fval : str
+        The specified fixed effects. (i.e. "X1+X2")
 
     Returns
     -------
-        vcov_type (str): The specified vcov type.
+    str
+        vcov_type (str) : The specified vcov type.
     """
     if vcov is None:
         # iid if no fixed effects
@@ -743,13 +841,20 @@ def _get_vcov_type(vcov, fval):
 
 def _drop_singletons(fixef_rm: bool) -> bool:
     """
-    Checks if the fixef_rm argument is set to "singleton". If so, returns True, else False.
-    Args:
-        fixef_rm (str): The fixef_rm argument.
+    Drop singleton fixed effects.
+
+    Checks if the fixef_rm argument is set to "singleton". If so, returns True,
+    else False.
+
+    Parameters
+    ----------
+    fixef_rm : str
+        The fixef_rm argument.
 
     Returns
     -------
-        drop_singletons (bool): Whether to drop singletons.
+    bool
+        drop_singletons (bool) : Whether to drop singletons.
     """
     return fixef_rm == "singleton"
 
@@ -760,14 +865,23 @@ def _get_endogvars_instruments(
     """
     Fetch the endogenous variables and instruments from the fml_dict_iv dictionary.
 
-    Args:
-        fml_dict_iv (dict): The dictionary of formulas for the IV estimation.
-        fval (str): The fixed effects. E.g. "X1+X2". "0" if no fixed effects.
-        depvar (str): The dependent variable.
-        covar (str): The covariates. E.g. "X1+X2+X3"
-    Returns:
-        endogvars (str): The endogenous variables.
-        instruments (str): The instruments. E.g. "Z1+Z2+Z3"
+    Parameters
+    ----------
+    fml_dict_iv : dict
+        The dictionary of formulas for the IV estimation.
+    fval : str
+        The fixed effects. E.g. "X1+X2". "0" if no fixed effects.
+    depvar : str
+        The dependent variable.
+    covar : str
+        The covariates. E.g. "X1+X2+X3"
+
+    Returns
+    -------
+    endogvars : str
+        The endogenous variables.
+    instruments : str
+        The instruments. E.g. "Z1+Z2+Z3"
     """
     dict2fe_iv = fml_dict_iv.get(fval)
     instruments2 = dict2fe_iv.get(depvar)[0].split("~")[1]

--- a/pyfixest/FixestMulti.py
+++ b/pyfixest/FixestMulti.py
@@ -1,7 +1,6 @@
 import warnings
 from typing import Optional, Union
 
-
 import numpy as np
 import pandas as pd
 

--- a/pyfixest/FormulaParser.py
+++ b/pyfixest/FormulaParser.py
@@ -13,7 +13,8 @@ class FixestFormulaParser:
     """
     A class for deparsing formulas with multiple estimation syntax.
 
-    Methods:
+    Methods
+    -------
         __init__(self, fml): Constructor method that initializes the object with a given formula.
         get_fml_dict(self): Returns a dictionary of all fevars & formula without fevars.
         get_var_dict(self): Returns a dictionary of all fevars and list of covars and depvars used in regression with those fevars.
@@ -27,11 +28,11 @@ class FixestFormulaParser:
         Args:
         fml (str): A one-to three sided formula string in the form "Y1 + Y2 ~ X1 + X2 | FE1 + FE2 | endogvar ~ exogvar".
 
-        Returns:
+        Returns
+        -------
             None
 
         """
-
         # Clean up the formula string
         fml = "".join(fml.split())
 
@@ -137,10 +138,13 @@ class FixestFormulaParser:
         """
         Get a nested dictionary of all formulas.
 
-        Parameters:
+        Parameters
+        ----------
             iv: bool (default: False)
                 If True, the formulas for the first stage are returned. Otherwise, the formulas for the second stage are returned.
-        Returns:
+
+        Returns
+        -------
             fml_dict: dict
                 A nested dictionary of all formulas. The dictionary has the following structure: first, a dictionary with the
                 fixed effects combinations as keys. Then, for each fixed effect combination, a dictionary with the dependent variables
@@ -149,7 +153,6 @@ class FixestFormulaParser:
                 Here is an example:
                     fml = Y1 + Y2 ~ X1 + X2 | FE1 + FE2 is transformed into: {"FE1 + FE2": {"Y1": "Y2 ~X1+X2", "Y2":"X1+X2"}}
         """
-
         fml_dict = {}
 
         for fevar in self.fevars_fml:
@@ -176,13 +179,13 @@ def _unpack_fml(x):
     and returns a dictionary containing the result. The dictionary has the following keys: 'constant', 'sw', 'sw0', 'csw'.
     The values are lists of variables of the respective type.
 
-    Parameters:
-    -----------
+    Parameters
+    ----------
     x : str
         The formula string to unpack.
 
-    Returns:
-    --------
+    Returns
+    -------
     res_s : dict
         A dictionary containing the unpacked formula. The dictionary has the following keys:
             - 'constant' : list of str
@@ -200,8 +203,8 @@ def _unpack_fml(x):
                 Each element in the list can be either a single variable string, or a list of variable strings
                 if multiple variables are listed in the switch.
 
-    Raises:
-    -------
+    Raises
+    ------
     ValueError:
         If the switch type is not one of 'sw', 'sw0', 'csw', or 'csw0'.
 
@@ -214,7 +217,6 @@ def _unpack_fml(x):
      'sw0': ['d'],
      'csw0': [['y1', 'y2', 'y3']]}
     """
-
     # Split the formula into its constituent variables
     var_split = x.split("+")
 
@@ -264,7 +266,6 @@ def _pack_to_fml(unpacked):
                 if multiple variables are listed in the switch.
             - 'csw0' : list of str or list of lists of str
     """
-
     res = {"constant": unpacked.get("constant", [])}
 
     # add up all variable constants (only required for csw)
@@ -328,7 +329,8 @@ def _find_sw(x):
     Args:
         x (str): The string to search for matches in.
 
-    Returns:
+    Returns
+    -------
         (list[str] or str, str or None): If any matches were found, returns a tuple containing
         a list of the elements found and the type of match (either 'sw', 'sw0', 'csw', or 'csw0').
         Otherwise, returns the original string and None.
@@ -336,7 +338,6 @@ def _find_sw(x):
     Example:
         _find_sw('sw(var1, var2)') -> (['var1', ' var2'], 'sw')
     """
-
     # Search for matches in the string
     sw_match = re.findall(r"sw\((.*?)\)", x)
     csw_match = re.findall(r"csw\((.*?)\)", x)
@@ -369,16 +370,17 @@ def _flatten_list(lst):
     Args:
         lst (list): A list that may contain sublists.
 
-    Returns:
+    Returns
+    -------
         list: A flattened list with no sublists.
 
-    Examples:
+    Examples
+    --------
         >>> flatten_list([[1, 2, 3], 4, 5])
         [1, 2, 3, 4, 5]
         >>> flatten_list([1, 2, 3])
         [1, 2, 3]
     """
-
     flattened_list = []
     for i in lst:
         if isinstance(i, list):
@@ -396,10 +398,10 @@ def _check_duplicate_key(my_dict, key):
         my_dict (dict): The dictionary to check for duplicate keys.
         key (str): The key to check for in the dictionary.
 
-    Returns:
+    Returns
+    -------
         None
     """
-
     for key in ["sw", "csw", "sw0", "csw0"]:
         if key in my_dict:
             raise DuplicateKeyError(

--- a/pyfixest/FormulaParser.py
+++ b/pyfixest/FormulaParser.py
@@ -15,18 +15,24 @@ class FixestFormulaParser:
 
     Methods
     -------
-        __init__(self, fml): Constructor method that initializes the object with a given formula.
-        get_fml_dict(self): Returns a dictionary of all fevars & formula without fevars.
-        get_var_dict(self): Returns a dictionary of all fevars and list of covars and depvars used in regression with those fevars.
+        __init__(self, fml): Constructor method that initializes the object with
+        a given formula.
+        get_fml_dict(self): Returns a dictionary of all fevars & formula without
+        fevars.
+        get_var_dict(self): Returns a dictionary of all fevars and list of covars
+        and depvars used in regression with those fevars.
 
     """
 
     def __init__(self, fml):
         """
-        Constructor method that initializes the object with a given formula.
+        Initialize the object with a given formula using constructor method.
 
-        Args:
-        fml (str): A one-to three sided formula string in the form "Y1 + Y2 ~ X1 + X2 | FE1 + FE2 | endogvar ~ exogvar".
+        Parameters
+        ----------
+        fml : str
+            A one-to three sided formula string in the form
+            "Y1 + Y2 ~ X1 + X2 | FE1 + FE2 | endogvar ~ exogvar".
 
         Returns
         -------
@@ -48,15 +54,15 @@ class FixestFormulaParser:
             if "~" in fml_split[1]:
                 fevars = "0"
                 endogvars, instruments = fml_split[1].split("~")
-                # add endogeneous variable to "covars" - yes, bad naming
+                # add endogenous variable to "covars" - yes, bad naming
 
-                # check if any of the instruments or endogeneous variables are also specified
-                # as covariates
+                # check if any of the instruments or endogenous variables are
+                # also specified as covariates
                 if any(
                     element in covars.split("+") for element in endogvars.split("+")
                 ):
                     raise EndogVarsAsCovarsError(
-                        "Endogeneous variables are specified as covariates in the first part of the three-part formula. This is not allowed."
+                        "Endogenous variables are specified as covariates in the first part of the three-part formula. This is not allowed."
                     )
 
                 if any(
@@ -75,11 +81,11 @@ class FixestFormulaParser:
             fevars = fml_split[1]
             endogvars, instruments = fml_split[2].split("~")
 
-            # check if any of the instruments or endogeneous variables are also specified
-            # as covariates
+            # check if any of the instruments or endogenous variables are also
+            # specified as covariates
             if any(element in covars.split("+") for element in endogvars.split("+")):
                 raise EndogVarsAsCovarsError(
-                    "Endogeneous variables are specified as covariates in the first part of the three-part formula. This is not allowed."
+                    "Endogenous variables are specified as covariates in the first part of the three-part formula. This is not allowed."
                 )
 
             if any(element in covars.split("+") for element in instruments.split("+")):
@@ -87,7 +93,7 @@ class FixestFormulaParser:
                     "Instruments are specified as covariates in the first part of the three-part formula. This is not allowed."
                 )
 
-            # add endogeneous variable to "covars" - yes, bad naming
+            # add endogenous variable to "covars" - yes, bad naming
             covars = endogvars if covars == "1" else f"{endogvars}+{covars}"
 
         if endogvars is not None:
@@ -113,7 +119,7 @@ class FixestFormulaParser:
         # clean instruments
         if instruments is not None:
             self._is_iv = True
-            # all rhs variables for the first stage (endog variable replaced with instrument)
+            # all rhs variables for the first stage (endog variable replaced with instrument)  # noqa: W505
             first_stage_covars_list = covars.split("+")
             first_stage_covars_list[first_stage_covars_list.index(endogvars)] = (
                 instruments
@@ -140,18 +146,23 @@ class FixestFormulaParser:
 
         Parameters
         ----------
-            iv: bool (default: False)
-                If True, the formulas for the first stage are returned. Otherwise, the formulas for the second stage are returned.
+        iv : bool (default: False)
+            If True, the formulas for the first stage are returned. Otherwise,
+            the formulas for the second stage are returned.
 
         Returns
         -------
-            fml_dict: dict
-                A nested dictionary of all formulas. The dictionary has the following structure: first, a dictionary with the
-                fixed effects combinations as keys. Then, for each fixed effect combination, a dictionary with the dependent variables
-                as keys. Finally, for each dependent variable, a list of formulas as values.
+        fml_dict: dict
+            A nested dictionary of all formulas. The dictionary has the following
+            structure:
+            First, a dictionary with the fixed effects combinations as keys.
+            Then, for each fixed effect combination, a dictionary with the
+            dependent variables as keys.
+            Finally, for each dependent variable, a list of formulas as values.
 
-                Here is an example:
-                    fml = Y1 + Y2 ~ X1 + X2 | FE1 + FE2 is transformed into: {"FE1 + FE2": {"Y1": "Y2 ~X1+X2", "Y2":"X1+X2"}}
+            Here is an example:
+                fml = Y1 + Y2 ~ X1 + X2 | FE1 + FE2 is transformed into:
+                {"FE1 + FE2": {"Y1": "Y2 ~X1+X2", "Y2":"X1+X2"}}
         """
         fml_dict = {}
 
@@ -175,8 +186,13 @@ class FixestFormulaParser:
 
 def _unpack_fml(x):
     """
-    Given a formula string `x` - e.g. 'X1 + csw(X2, X3)' - , splits it into its constituent variables and their types (if any),
-    and returns a dictionary containing the result. The dictionary has the following keys: 'constant', 'sw', 'sw0', 'csw'.
+    Parse a formula string.
+
+    Given a formula string `x` - e.g. 'X1 + csw(X2, X3)' - , splits it into its
+    constituent variables and their types (if any), and returns a dictionary
+    containing the result. The dictionary has the following keys: 'constant',
+    'sw', 'sw0', 'csw'.
+
     The values are lists of variables of the respective type.
 
     Parameters
@@ -187,21 +203,28 @@ def _unpack_fml(x):
     Returns
     -------
     res_s : dict
-        A dictionary containing the unpacked formula. The dictionary has the following keys:
+        A dictionary containing the unpacked formula. The dictionary has the
+        following keys:
             - 'constant' : list of str
                 The list of constant (i.e., non-switched) variables in the formula.
             - 'sw' : list of str
-                The list of variables that have a regular switch (i.e., 'sw(var1, var2, ...)' notation) in the formula.
+                The list of variables that have a regular switch
+                (i.e., 'sw(var1, var2, ...)' notation) in the formula.
             - 'sw0' : list of str
-                The list of variables that have a 'sw0(var1, var2, ..)' switch in the formula.
+                The list of variables that have a 'sw0(var1, var2, ..)' switch
+                in the formula.
             - 'csw' : list of str or list of lists of str
-                The list of variables that have a 'csw(var1, var2, ..)' switch in the formula.
-                Each element in the list can be either a single variable string, or a list of variable strings
-                if multiple variables are listed in the switch.
+                The list of variables that have a 'csw(var1, var2, ..)' switch
+                in the formula.
+                Each element in the list can be either a single variable string,
+                or a list of variable strings if multiple variables are listed
+                in the switch.
             - 'csw0' : list of str or list of lists of str
-                The list of variables that have a 'csw0(var1,var2,...)' switch in the formula.
-                Each element in the list can be either a single variable string, or a list of variable strings
-                if multiple variables are listed in the switch.
+                The list of variables that have a 'csw0(var1,var2,...)' switch
+                in the formula.
+                Each element in the list can be either a single variable string,
+                or a list of variable strings if multiple variables are listed
+                in the switch.
 
     Raises
     ------
@@ -247,23 +270,31 @@ def _unpack_fml(x):
 
 def _pack_to_fml(unpacked):
     """
-    Given a dictionary of "unpacked" formula variables, returns a string containing formulas. An "unpacked" formula is a
-    deparsed formula that allows for multiple estimations.
+    Generate a formula string from a dictionary of "unpacked" formula variables.
+
+    Given a dictionary of "unpacked" formula variables, returns a string containing
+    formulas. An "unpacked" formula is a deparsed formula that allows for multiple
+    estimations.
 
     Parameters
     ----------
     unpacked : dict
-        A dictionary of unpacked formula variables. The dictionary has the following keys:
+        A dictionary of unpacked formula variables. The dictionary has the following
+        keys:
             - 'constant' : list of str
                 The list of constant (i.e., non-switched) variables in the formula.
             - 'sw' : list of str
-                The list of variables that have a regular switch (i.e., 'sw(var1, var2, ...)' notation) in the formula.
+                The list of variables that have a regular switch
+                (i.e., 'sw(var1, var2, ...)' notation) in the formula.
             - 'sw0' : list of str
-                The list of variables that have a 'sw0(var1, var2, ..)' switch in the formula.
+                The list of variables that have a 'sw0(var1, var2, ..)' switch
+                in the formula.
             - 'csw' : list of str or list of lists of str
-                The list of variables that have a 'csw(var1, var2, ..)' switch in the formula.
-                Each element in the list can be either a single variable string, or a list of variable strings
-                if multiple variables are listed in the switch.
+                The list of variables that have a 'csw(var1, var2, ..)' switch
+                in the formula.
+                Each element in the list can be either a single variable string,
+                or a list of variable strings if multiple variables are listed
+                in the switch.
             - 'csw0' : list of str or list of lists of str
     """
     res = {"constant": unpacked.get("constant", [])}
@@ -323,16 +354,23 @@ def _pack_to_fml(unpacked):
 
 def _find_sw(x):
     """
-    Search for matches in a string. Matches are either 'sw', 'sw0', 'csw', 'csw0'. If a match is found, returns a
-    tuple containing a list of the elements found and the type of match. Otherwise, returns the original string and None.
+    Search for matches in a string.
 
-    Args:
-        x (str): The string to search for matches in.
+    Matches are either 'sw', 'sw0', 'csw', 'csw0'. If a match is found, returns a
+    tuple containing a list of the elements found and the type of match. Otherwise,
+    returns the original string and None.
+
+    Parameters
+    ----------
+    x : str
+        The string to search for matches in.
 
     Returns
     -------
-        (list[str] or str, str or None): If any matches were found, returns a tuple containing
-        a list of the elements found and the type of match (either 'sw', 'sw0', 'csw', or 'csw0').
+    list[str] or str, str or None
+        If any matches were found, returns a
+        tuple containing a list of the elements found and the type of match
+        (either 'sw', 'sw0', 'csw', or 'csw0').
         Otherwise, returns the original string and None.
 
     Example:
@@ -367,12 +405,15 @@ def _flatten_list(lst):
     """
     Flattens a list that may contain sublists.
 
-    Args:
-        lst (list): A list that may contain sublists.
+    Parameters
+    ----------
+    lst : list
+        A list that may contain sublists.
 
     Returns
     -------
-        list: A flattened list with no sublists.
+    list
+        A flattened list with no sublists.
 
     Examples
     --------
@@ -392,11 +433,17 @@ def _flatten_list(lst):
 
 def _check_duplicate_key(my_dict, key):
     """
-    Checks if a key already exists in a dictionary. If it does, raises a DuplicateKeyError. Otherwise, does nothing.
+    Identify duplicate keys.
 
-    Args:
-        my_dict (dict): The dictionary to check for duplicate keys.
-        key (str): The key to check for in the dictionary.
+    Checks if a key already exists in a dictionary. If it does, raises a
+    DuplicateKeyError. Otherwise, does nothing.
+
+    Parameters
+    ----------
+    my_dict : dict
+        The dictionary to check for duplicate keys.
+    key : str
+        The key to check for in the dictionary.
 
     Returns
     -------
@@ -406,7 +453,8 @@ def _check_duplicate_key(my_dict, key):
         if key in my_dict:
             raise DuplicateKeyError(
                 f"""
-                Duplicate key found: "{key}. Multiple estimation syntax can only be used once on the rhs of the two-sided formula.
+                Duplicate key found: "{key}. Multiple estimation syntax can
+                only be used once on the rhs of the two-sided formula.
                 """
             )
         else:

--- a/pyfixest/demean.py
+++ b/pyfixest/demean.py
@@ -1,6 +1,5 @@
 from typing import Any, Optional
 
-
 import numba as nb
 import numpy as np
 import pandas as pd

--- a/pyfixest/demean.py
+++ b/pyfixest/demean.py
@@ -16,23 +16,29 @@ def demean_model(
     """
     Demean a regression model.
 
-    Demeans a single regression model via the alternating projections algorithm (see `demean` function). Prior to demeaning, the function checks if some of the variables have already been demeaned and uses values from the cache `lookup_demeaned_data` if possible. If the model has no fixed effects, the function does not demean the data.
+    Demeans a single regression model via the alternating projections algorithm
+    (see `demean` function). Prior to demeaning, the function checks if some of
+    the variables have already been demeaned and uses values from the cache
+    `lookup_demeaned_data` if possible. If the model has no fixed effects, the
+    function does not demean the data.
 
     Parameters
     ----------
-    Y : pd.DataFrame
+    Y : pandas.DataFrame
         A DataFrame of the dependent variable.
-    X : pd.DataFrame
+    X : pandas.DataFrame
         A DataFrame of the covariates.
-    fe : pd.DataFrame or None
+    fe : pandas.DataFrame or None
         A DataFrame of the fixed effects. None if no fixed effects specified.
-    weights : np.ndarray or None
+    weights : numpy.ndarray or None
         A numpy array of weights. None if no weights.
     lookup_demeaned_data : dict[str, Any]
-        A dictionary with keys for each fixed effects combination and potentially values of demeaned data frames.
-        The function checks this dictionary to see if some of the variables have already been demeaned.
+        A dictionary with keys for each fixed effects combination and potentially
+        values of demeaned data frames. The function checks this dictionary to
+        see if some of the variables have already been demeaned.
     na_index_str : str
-        A string with indices of dropped columns. Used for caching of demeaned variables.
+        A string with indices of dropped columns. Used for caching of demeaned
+        variables.
 
     Returns
     -------
@@ -171,17 +177,17 @@ def demean(
     """
     Demean an array.
 
-    Workhorse for demeaning an input array `x` based on the specified fixed effects and weights
-    via the alternating projections algorithm.
+    Workhorse for demeaning an input array `x` based on the specified fixed
+    effects and weights via the alternating projections algorithm.
 
     Parameters
     ----------
-    x : np.ndarray
+    x : numpy.ndarray
         Input array of shape (n_samples, n_features). Needs to be of type float.
-    flist : np.ndarray
-        Array of shape (n_samples, n_factors) specifying the fixed effects. Needs to already be
-        converted to integers.
-    weights : np.ndarray
+    flist : numpy.ndarray
+        Array of shape (n_samples, n_factors) specifying the fixed effects.
+        Needs to already be converted to integers.
+    weights : numpy.ndarray
         Array of shape (n_samples,) specifying the weights.
     tol : float, optional
         Tolerance criterion for convergence. Defaults to 1e-08.
@@ -190,7 +196,7 @@ def demean(
 
     Returns
     -------
-    tuple[np.ndarray, bool]
+    tuple[numpy.ndarray, bool]
         A tuple containing the demeaned array of shape (n_samples, n_features)
         and a boolean indicating whether the algorithm converged successfully.
     """

--- a/pyfixest/detect_singletons.py
+++ b/pyfixest/detect_singletons.py
@@ -58,7 +58,6 @@ def detect_singletons(ids):
     For performance reasons, the input array should be in column-major order. Operating on a row-major array can lead to
     significant performance losses.
     """
-
     ids = _prepare_fixed_effects(ids)
     n_samples, n_features = ids.shape
 

--- a/pyfixest/detect_singletons.py
+++ b/pyfixest/detect_singletons.py
@@ -35,28 +35,33 @@ def detect_singletons(ids):
     """
     Detect singleton fixed effects in a dataset.
 
-    This function iterates over the columns of a 2D numpy array representing fixed effects to identify singleton fixed effects.
-    An observation is considered a singleton if it is the only one in its group (fixed effect identifier).
+    This function iterates over the columns of a 2D numpy array representing
+    fixed effects to identify singleton fixed effects.
+    An observation is considered a singleton if it is the only one in its group
+    (fixed effect identifier).
 
     Parameters
     ----------
     ids : np.ndarray
-        A 2D numpy array representing fixed effects, with a shape of (n_samples, n_features).
+        A 2D numpy array representing fixed effects, with a shape of (n_samples,
+        n_features).
         Elements should be non-negative integers representing fixed effect identifiers.
 
     Returns
     -------
-    np.ndarray
-        A boolean array of shape (n_samples,), indicating which observations have a singleton fixed effect.
+    numpy.ndarray
+        A boolean array of shape (n_samples,), indicating which observations have
+        a singleton fixed effect.
 
     Notes
     -----
-    The algorithm iterates over columns to identify fixed effects. After each column is processed, it updates the record of
-    non-singleton rows. This approach accounts for the possibility that removing an observation in one column can lead to the
-    emergence of new singletons in subsequent columns.
+    The algorithm iterates over columns to identify fixed effects. After each
+    column is processed, it updates the record of non-singleton rows. This approach
+    accounts for the possibility that removing an observation in one column can
+    lead to the emergence of new singletons in subsequent columns.
 
-    For performance reasons, the input array should be in column-major order. Operating on a row-major array can lead to
-    significant performance losses.
+    For performance reasons, the input array should be in column-major order.
+    Operating on a row-major array can lead to significant performance losses.
     """
     ids = _prepare_fixed_effects(ids)
     n_samples, n_features = ids.shape

--- a/pyfixest/dev_utils.py
+++ b/pyfixest/dev_utils.py
@@ -10,7 +10,7 @@ except ImportError:
     DataFrameType = pd.DataFrame
 
 
-def _polars_to_pandas(data: DataFrameType) -> pd.DataFrame:
+def _polars_to_pandas(data: DataFrameType) -> pd.DataFrame:  # type: ignore
     if not isinstance(data, pd.DataFrame):
         try:
             import polars as pl  # noqa: F401
@@ -18,7 +18,8 @@ def _polars_to_pandas(data: DataFrameType) -> pd.DataFrame:
             data = data.to_pandas()
         except ImportError:
             raise ImportError(
-                "Polars is not installed. Please install Polars to use it as an alternative."
+                """Polars is not installed. Please install Polars to use it as
+                an alternative."""
             )
 
     return data

--- a/pyfixest/did/__init__.py
+++ b/pyfixest/did/__init__.py
@@ -1,7 +1,7 @@
 print(
     """
-      You have loaded the 'pyfixest.did' module. While every function is tested in `tests/test_did.py`,
-      the module is not yet as thoroughly tested as I would like. So please use it with caution and
-      provide feedback in case you stumble over any bugs!
-      """
+    You have loaded the 'pyfixest.did' module. While every function is tested in `tests/test_did.py`,
+    the module is not yet as thoroughly tested as I would like. So please use it with caution and
+    provide feedback in case you stumble over any bugs!
+    """
 )

--- a/pyfixest/did/did.py
+++ b/pyfixest/did/did.py
@@ -19,10 +19,11 @@ class DID(ABC):
             att: Whether to estimate the average treatment effect on the treated (ATT) or the
                 canonical event study design with all leads and lags. Default is True.
             cluster: The name of the cluster variable.
-        Returns:
+
+        Returns
+        -------
             None
         """
-
         # do some checks here
 
         self._data = data.copy()

--- a/pyfixest/did/did.py
+++ b/pyfixest/did/did.py
@@ -24,8 +24,6 @@ class DID(ABC):
         have a value of 0.
     xfml : str
         The formula for the covariates.
-    estimator: str
-        The estimator to use. Default is "did2s".
     att : str
         Whether to estimate the average treatment effect on the treated (ATT) or
         the canonical event study design with all leads and lags. Default is True.

--- a/pyfixest/did/did.py
+++ b/pyfixest/did/did.py
@@ -2,28 +2,39 @@ from abc import ABC, abstractmethod
 
 
 class DID(ABC):
+    """
+    A class used to represent the DID (Differences-in-Differences) model.
+
+    Attributes
+    ----------
+    data : pandas.DataFrame
+        The DataFrame containing all variables.
+    yname : str
+        The name of the dependent variable.
+    idname : str
+        The name of the identifier variable.
+    tname : str
+        Variable name for calendar period. Must be an integer in the format
+        YYYYMMDDHHMMSS, i.e. it must be possible to compare two dates via '>'.
+        Datetime variables are currently not accepted.
+    gname : str
+        unit-specific time of initial treatment. Must be an integer in the format
+        YYYYMMDDHHMMSS, i.e. it must be possible to compare two dates via '>'.
+        Datetime variables are currently not accepted. Never treated units must
+        have a value of 0.
+    xfml : str
+        The formula for the covariates.
+    estimator: str
+        The estimator to use. Default is "did2s".
+    att : str
+        Whether to estimate the average treatment effect on the treated (ATT) or
+        the canonical event study design with all leads and lags. Default is True.
+    cluster : str
+        The name of the cluster variable.
+    """
+
     @abstractmethod
     def __init__(self, data, yname, idname, tname, gname, xfml, att, cluster):
-        """
-        Args:
-            data: The DataFrame containing all variables.
-            yname: The name of the dependent variable.
-            idname: The name of the id variable.
-            tname: Variable name for calendar period. Must be an integer in the format YYYYMMDDHHMMSS, i.e. it must be
-                   possible to compare two dates via '>'. Date time variables are currently not accepted.
-            gname: unit-specific time of initial treatment. Must be an integer in the format YYYYMMDDHHMMSS, i.e. it must be
-                   possible to compare two dates via '>'. Date time variables are currently not accepted. Never treated units
-                   must have a value of 0.
-            xfml: The formula for the covariates.
-            estimator: The estimator to use. Options are "did2s".
-            att: Whether to estimate the average treatment effect on the treated (ATT) or the
-                canonical event study design with all leads and lags. Default is True.
-            cluster: The name of the cluster variable.
-
-        Returns
-        -------
-            None
-        """
         # do some checks here
 
         self._data = data.copy()
@@ -59,7 +70,9 @@ class DID(ABC):
             "float32",
         ]:
             raise ValueError(
-                f"The variable {self._tname} must be of a numeric type, and more specifically, in the format YYYYMMDDHHMMSS. I.e. either 2012, 2013, etc or 201201, 201202, 201203 etc."
+                f"""The variable {self._tname} must be of a numeric type, and more
+                specifically, in the format YYYYMMDDHHMMSS. I.e. either 2012, 2013,
+                etc. or 201201, 201202, 201203 etc."""
             )
         if self._data[self._gname].dtype not in [
             "int64",
@@ -69,7 +82,9 @@ class DID(ABC):
             "float32",
         ]:
             raise ValueError(
-                f"The variable {self._tname} must be of a numeric type, and more specifically, in the format YYYYMMDDHHMMSS. I.e. either 2012, 2013, etc or 201201, 201202, 201203 etc."
+                f"""The variable {self._tname} must be of a numeric type, and more
+                specifically, in the format YYYYMMDDHHMMSS. I.e. either 2012, 2013,
+                etc. or 201201, 201202, 201203 etc."""
             )
 
         # create a treatment variable
@@ -78,21 +93,21 @@ class DID(ABC):
         )
 
     @abstractmethod
-    def estimate(self):
+    def estimate(self):  # noqa: D102
         pass
 
     @abstractmethod
-    def vcov(self):
+    def vcov(self):  # noqa: D102
         pass
 
     @abstractmethod
-    def iplot(self):
+    def iplot(self):  # noqa: D102
         pass
 
     @abstractmethod
-    def tidy(self):
+    def tidy(self):  # noqa: D102
         pass
 
     @abstractmethod
-    def summary(self):
+    def summary(self):  # noqa: D102
         pass

--- a/pyfixest/did/did2s.py
+++ b/pyfixest/did/did2s.py
@@ -13,32 +13,39 @@ from pyfixest.model_matrix_fixest import model_matrix_fixest
 
 class DID2S(DID):
     """
-    Difference-in-Differences estimation using Gardner's two-step DID2S estimator (2021).
+    Difference-in-Differences estimation using Gardner(2021) two-step DID2S estimator.
 
-    Multiple parts of this code are direct translations of Kyle Butt's R code `did2s`, published
-    under MIT license: https://github.com/kylebutts/did2s/tree/main.
+    Multiple parts of this code are direct translations of Kyle Butt's R code
+    `did2s`, published under MIT license: https://github.com/kylebutts/did2s/tree/main.
+
+    Attributes
+    ----------
+    data : pandas.DataFrame
+        The DataFrame containing all variables.
+    yname : str
+        The name of the dependent variable.
+    idname : str
+        The name of the identifier variable.
+    tname : str
+        Variable name for calendar period. Must be an integer in the format
+        YYYYMMDDHHMMSS, i.e. it must be possible to compare two dates via '>'.
+        Datetime variables are currently not accepted.
+    gname : str
+        unit-specific time of initial treatment. Must be an integer in the format
+        YYYYMMDDHHMMSS, i.e. it must be possible to compare two dates via '>'.
+        Datetime variables are currently not accepted. Never treated units
+        must have a value of 0.
+    xfml : str
+        The formula for the covariates.
+    att : str
+        Whether to estimate the pooled average treatment effect on the treated
+        (ATT) or the canonical event study design with all leads and lags / the
+        ATT for each period. Default is True.
+    cluster : str
+        The name of the cluster variable.
     """
 
     def __init__(self, data, yname, idname, tname, gname, xfml, att, cluster):
-        """
-        Args:
-            data: The DataFrame containing all variables.
-            yname: The name of the dependent variable.
-            idname: The name of the id variable.
-            tname: Variable name for calendar period. Must be an integer in the format YYYYMMDDHHMMSS, i.e. it must be
-                   possible to compare two dates via '>'. Date time variables are currently not accepted.
-            gname: unit-specific time of initial treatment. Must be an integer in the format YYYYMMDDHHMMSS, i.e. it must be
-                     possible to compare two dates via '>'. Date time variables are currently not accepted. Never treated units
-                     must have a value of 0.
-            xfml: The formula for the covariates.
-            att: Whether to estimate the pooled average treatment effect on the treated (ATT) or the
-                canonical event study design with all leads and lags / the ATT for each period. Default is True.
-            cluster (str): The name of the cluster variable.
-
-        Returns
-        -------
-            None
-        """
         super().__init__(data, yname, idname, tname, gname, xfml, att, cluster)
 
         self._estimator = "did2s"
@@ -51,18 +58,7 @@ class DID2S(DID):
             self._fml2 = " ~ 0 + ATT"
 
     def estimate(self):
-        """
-        Args:
-            data (pd.DataFrame): The DataFrame containing all variables.
-            yname (str): The name of the dependent variable.
-            _first_stage (str): The formula for the first stage.
-            _second_stage (str): The formula for the second stage.
-            treatment (str): The name of the treatment variable.
-
-        Returns
-        -------
-            tba
-        """
+        """Estimate the two-step DID2S model."""
         return _did2s_estimate(
             data=self._data,
             yname=self._yname,
@@ -72,6 +68,17 @@ class DID2S(DID):
         )  # returns triple Feols, first_u, second_u
 
     def vcov(self):
+        """
+        Variance-covariance matrix.
+
+        Calculates the variance-covariance matrix of the coefficient estimates
+        for the Difference-in-Differences (DiD) estimator.
+
+        Returns
+        -------
+        array_like
+            The variance-covariance matrix of the coefficient estimates.
+        """
         return _did2s_vcov(
             data=self._data,
             yname=self._yname,
@@ -93,6 +100,7 @@ class DID2S(DID):
         title="DID2S Event Study Estimate",
         coord_flip=False,
     ):
+        """Plot DID estimates."""
         self.iplot(
             alpha=alpha,
             figsize=figsize,
@@ -103,10 +111,10 @@ class DID2S(DID):
             coord_flip=coord_flip,
         )
 
-    def tidy(self):
+    def tidy(self):  # noqa: D102
         return self.tidy()
 
-    def summary(self):
+    def summary(self):  # noqa: D102
         return self.summary()
 
 
@@ -120,17 +128,30 @@ def _did2s_estimate(
     i_ref2: Optional[Union[int, str, list]] = None,
 ):
     """
-    Args:
-        data (pd.DataFrame): The DataFrame containing all variables.
-        yname (str): The name of the dependent variable.
-        _first_stage (str): The formula for the first stage.
-        _second_stage (str): The formula for the second stage.
-        treatment (str): The name of the treatment variable. Must be boolean.
-        i_ref1 (int, str or list): The reference value(s) for the first variable used with "i()" syntax. Only applicable for the second stage formula.
-        i_ref2 (int, str or list): The reference value(s) for the second variable used with "i()" syntax. Only applicable for the second stage formula.
+    Estimate the two-step DID2S model.
+
+    Parameters
+    ----------
+    data: pd.DataFrame
+        The DataFrame containing all variables.
+    yname:str
+        The name of the dependent variable.
+    _first_stage: str
+        The formula for the first stage.
+    _second_stage: str
+        The formula for the second stage.
+    treatment: str
+        The name of the treatment variable. Must be boolean.
+    i_ref1: int, str or list
+        The reference value(s) for the first variable used with "i()" syntax.
+        Only applicable for the second stage formula.
+    i_ref2: int, str or list
+        The reference value(s) for the second variable used with "i()" syntax.
+        Only applicable for the second stage formula.
 
     Returns
     -------
+    object
         A fitted model object of class feols and the first and second stage residuals.
     """
     _first_stage_full = f"{yname} {_first_stage}"
@@ -181,7 +202,7 @@ def _did2s_estimate(
     _first_u = data[f"{yname}"].to_numpy().flatten() - Y_hat
     data[f"{yname}_hat"] = _first_u
 
-    # intercept needs to be dropped by hand due to the presence of fixed effects in the first stage
+    # intercept needs to be dropped by hand due to the presence of fixed effects in the first stage  # noqa: W505
     fit2 = feols(
         _second_stage_full,
         data=data,
@@ -208,18 +229,35 @@ def _did2s_vcov(
     i_ref2: Optional[Union[int, str, list]] = None,
 ):
     """
-    Compute a variance covariance matrix for Gardner's 2-stage Difference-in-Differences Estimator.
-    Args:
-        data (pd.DataFrame): The DataFrame containing all variables.
-        yname (str): The name of the dependent variable.
-        first_stage (str): The formula for the first stage.
-        second_stage (str): The formula for the second stage.
-        treatment (str): The name of the treatment variable.
-        first_u (np.ndarray): The first stage residuals.
-        second_u (np.ndarray): The second stage residuals.
-        cluster (str): The name of the cluster variable.
-        i_ref1 (int, str or list): The reference value(s) for the first variable used with "i()" syntax. Only applicable for the second stage formula.
-        i_ref2 (int, str or list): The reference value(s) for the second variable used with "i()" syntax. Only applicable for the second stage formula.
+    Variance-Covariance matrix for DID2S.
+
+    Compute a variance covariance matrix for Gardner's 2-stage Difference-in-Differences
+    Estimator.
+
+    Parameters
+    ----------
+    data: pandas.DataFrame
+        The DataFrame containing all variables.
+    yname: str
+        The name of the dependent variable.
+    first_stage: str
+        The formula for the first stage.
+    second_stage: str
+        The formula for the second stage.
+    treatment: str
+        The name of the treatment variable.
+    first_u: np.ndarray
+        The first stage residuals.
+    second_u: np.ndarray
+        The second stage residuals.
+    cluster: str
+        The name of the cluster variable.
+    i_ref1: int, str or list
+        The reference value(s) for the first variable used with "i()" syntax.
+        Only applicable for the second stage formula.
+    i_ref2: int, str or list
+        The reference value(s) for the second variable used with "i()" syntax.
+        Only applicable for the second stage formula.
 
     Returns
     -------
@@ -230,7 +268,7 @@ def _did2s_vcov(
 
     _G = clustid.nunique()  # actually not used here, neither in did2s
 
-    # some formula parsing to get the correct formula for the first and second stage model matrix
+    # some formula parsing to get the correct formula for the first and second stage model matrix  # noqa: W505
     first_stage_x, first_stage_fe = first_stage.split("|")
     first_stage_fe = [f"C({i})" for i in first_stage_fe.split("+")]
     first_stage_fe = "+".join(first_stage_fe)
@@ -238,8 +276,8 @@ def _did2s_vcov(
 
     second_stage = f"{second_stage}"
 
-    # note for future Alex: intercept needs to be dropped! it is not as fixed effects are converted to
-    # dummies, hence has_fixed checks are False
+    # note for future Alex: intercept needs to be dropped! it is not as fixed
+    # effects are converted to dummies, hence has_fixed checks are False
     _, X1, _, _, _, _, _, _, _, _ = model_matrix_fixest(
         fml=f"{yname} {first_stage}",
         data=data,

--- a/pyfixest/did/estimation.py
+++ b/pyfixest/did/estimation.py
@@ -20,11 +20,12 @@ def event_study(
     cluster="idname",
 ):
     """
-    Function for Event Study Estimation.
+    Estimate Event Study Model.
 
-    This function allows for the estimation of treatment effects using different estimators.
-    Currently, it supports "twfe" for the two-way fixed effects estimator and "did2s" for Gardner's two-step DID2S estimator.
-    Other estimators are in development.
+    This function allows for the estimation of treatment effects using different
+    estimators. Currently, it supports "twfe" for the two-way fixed effects
+    estimator and "did2s" for Gardner's two-step DID2S estimator. Other estimators
+    are in development.
 
     Parameters
     ----------
@@ -43,7 +44,9 @@ def event_study(
     estimator : str
         The estimator to use. Options are "did2s" and "twfe".
     att : bool, optional
-        If True, estimates the average treatment effect on the treated (ATT). If False, estimates the canonical event study design with all leads and lags. Default is True.
+        If True, estimates the average treatment effect on the treated (ATT).
+        If False, estimates the canonical event study design with all leads and
+        lags. Default is True.
 
     Returns
     -------
@@ -161,9 +164,11 @@ def did2s(
     cluster : str
         The name of the cluster variable.
     i_ref1 : int, str, list, optional
-        The reference value(s) for the first variable used with "i()" syntax in the second stage formula. Default is None.
+        The reference value(s) for the first variable used with "i()" syntax in
+        the second stage formula. Default is None.
     i_ref2 : int, str, list, optional
-        The reference value(s) for the second variable used with "i()" syntax in the second stage formula. Default is None.
+        The reference value(s) for the second variable used with "i()" syntax in
+        the second stage formula. Default is None.
 
     Returns
     -------
@@ -227,7 +232,11 @@ def did2s(
     # assert that there is no 0, -1 or - 1 in the second stage formula
     if "0" in second_stage or "-1" in second_stage:
         raise ValueError(
-            "The second stage formula should not contain '0' or '-1'. Note that the intercept is dropped automatically due to the presence of fixed effects in the first stage."
+            """
+            The second stage formula should not contain '0' or '-1'. Note that
+            the intercept is dropped automatically due to the presence of fixed
+            effects in the first stage.
+            """
         )
 
     data = data.copy()
@@ -281,7 +290,10 @@ def lpdid(
     xfml=None,
 ) -> pd.DataFrame:
     """
-    Estimate a Difference-in-Differences / Event Study Model via the Local Projections Approach.
+    Local projections approach to estimation.
+
+    Estimate a Difference-in-Differences / Event Study Model via the Local
+    Projections Approach.
 
     Parameters
     ----------
@@ -296,15 +308,19 @@ def lpdid(
     gname : str
         Unit-specific time of initial treatment.
     vcov : str, dict, optional
-        The type of inference to employ. Defaults to {"CRV1": idname}. Options include "iid", "hetero", or a dictionary like {"CRV1": idname}.
+        The type of inference to employ. Defaults to {"CRV1": idname}.
+        Options include "iid", "hetero", or a dictionary like {"CRV1": idname}.
     pre_window : int, optional
-        The number of periods before the treatment to include in the estimation. Default is the minimum relative year in the data.
+        The number of periods before the treatment to include in the estimation.
+        Default is the minimum relative year in the data.
     post_window : int, optional
-        The number of periods after the treatment to include in the estimation. Default is the maximum relative year in the data.
+        The number of periods after the treatment to include in the estimation.
+        Default is the maximum relative year in the data.
     never_treated : int, optional
         Value in gname indicating units never treated. Default is 0.
     att : bool, optional
-        If True, estimates the pooled average treatment effect on the treated (ATT). Default is False.
+        If True, estimates the pooled average treatment effect on the treated (ATT).
+        Default is False.
     xfml : str, optional
         Formula for the covariates. Not yet supported.
 

--- a/pyfixest/did/event_study.py
+++ b/pyfixest/did/event_study.py
@@ -48,7 +48,7 @@ def event_study(
         A fitted model object of class [Feols(/reference/Feols.qmd).
 
     Examples
-
+    --------
     ```{python}
     import pandas as pd
 

--- a/pyfixest/did/event_study.py
+++ b/pyfixest/did/event_study.py
@@ -19,8 +19,10 @@ def event_study(
     """
     Estimate a treatment effect using an event study design.
 
-    This function allows for the estimation of treatment effects using different estimators.
-    Currently, it supports "twfe" for the two-way fixed effects estimator and "did2s" for Gardner's two-step DID2S estimator.
+    This function allows for the estimation of treatment effects using different
+    estimators.
+    Currently, it supports "twfe" for the two-way fixed effects estimator and
+    "did2s" for Gardner's two-step DID2S estimator.
     Other estimators are in development.
 
     Parameters
@@ -40,7 +42,9 @@ def event_study(
     estimator : str
         The estimator to use. Options are "did2s" and "twfe".
     att : bool, optional
-        If True, estimates the average treatment effect on the treated (ATT). If False, estimates the canonical event study design with all leads and lags. Default is True.
+        If True, estimates the average treatment effect on the treated (ATT).
+        If False, estimates the canonical event study design with all leads and lags.
+        Default is True.
 
     Returns
     -------

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -10,7 +10,7 @@ from pyfixest.visualize import _coefplot
 
 class LPDID(DID):
     """
-    A class used to represent the Local Polynomial Differences-in-Differences model.
+    A class used to represent the Local Projections Differences-in-Differences Estimator.
 
     Attributes
     ----------

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -10,8 +10,7 @@ from pyfixest.visualize import _coefplot
 
 class LPDID(DID):
     """
-    A class used to represent the Local Projections Differences-in-Differences
-    Estimator.
+    A class used to represent the Local Projections Diff-in-Diff Estimator.
 
     Attributes
     ----------

--- a/pyfixest/did/lpdid.py
+++ b/pyfixest/did/lpdid.py
@@ -10,7 +10,8 @@ from pyfixest.visualize import _coefplot
 
 class LPDID(DID):
     """
-    A class used to represent the Local Projections Differences-in-Differences Estimator.
+    A class used to represent the Local Projections Differences-in-Differences
+    Estimator.
 
     Attributes
     ----------

--- a/pyfixest/did/twfe.py
+++ b/pyfixest/did/twfe.py
@@ -22,10 +22,11 @@ class TWFE(DID):
             att: Whether to estimate the average treatment effect on the treated (ATT) or the
                 canonical event study design with all leads and lags. Default is True.
             cluster (str): The name of the cluster variable.
-        Returns:
+
+        Returns
+        -------
             None
         """
-
         super().__init__(data, yname, idname, tname, gname, xfml, att, cluster)
 
         self._estimator = "twfe"
@@ -48,7 +49,6 @@ class TWFE(DID):
         """
         Method not needed. The vcov matrix is calculated via the [Feols(/reference/Feols.qmd) object.
         """
-
         pass
 
     def iplot(

--- a/pyfixest/did/twfe.py
+++ b/pyfixest/did/twfe.py
@@ -4,29 +4,38 @@ from pyfixest.estimation import feols
 
 class TWFE(DID):
     """
-    Estimate a Difference-in-Differences model using the two-way fixed effects estimator.
+    Estimate a Two-way Fixed Effects model.
+
+    Estimate a Difference-in-Differences model using the two-way fixed effects
+    estimator.
+
+    Attributes
+    ----------
+    data: pandas.DataFrame
+        The DataFrame containing all variables.
+    yname: str
+        The name of the dependent variable.
+    idname: str
+        The name of the id variable.
+    tname: str
+        Variable name for calendar period. Must be an integer in the format
+        YYYYMMDDHHMMSS, i.e. it must be possible to compare two dates via '>'.
+        Datetime variables are currently not accepted.
+    gname: str
+        Unit-specific time of initial treatment. Must be an integer in the format
+        YYYYMMDDHHMMSS, i.e. it must be possible to compare two dates via '>'.
+        Datetime variables are currently not accepted. Never treated units
+        must have a value of 0.
+    xfml: str
+        The formula for the covariates.
+    att: bool
+        Whether to estimate the average treatment effect on the treated (ATT) or the
+        canonical event study design with all leads and lags. Default is True.
+    cluster: str
+        The name of the cluster variable.
     """
 
     def __init__(self, data, yname, idname, tname, gname, xfml, att, cluster):
-        """
-        Args:
-            data: The DataFrame containing all variables.
-            yname: The name of the dependent variable.
-            idname: The name of the id variable.
-            tname: Variable name for calendar period. Must be an integer in the format YYYYMMDDHHMMSS, i.e. it must be
-                   possible to compare two dates via '>'. Date time variables are currently not accepted.
-            gname: unit-specific time of initial treatment. Must be an integer in the format YYYYMMDDHHMMSS, i.e. it must be
-                     possible to compare two dates via '>'. Date time variables are currently not accepted. Never treated units
-                     must have a value of 0.
-            xfml: The formula for the covariates.
-            att: Whether to estimate the average treatment effect on the treated (ATT) or the
-                canonical event study design with all leads and lags. Default is True.
-            cluster (str): The name of the cluster variable.
-
-        Returns
-        -------
-            None
-        """
         super().__init__(data, yname, idname, tname, gname, xfml, att, cluster)
 
         self._estimator = "twfe"
@@ -37,6 +46,7 @@ class TWFE(DID):
             self._fml = f"{yname} ~ ATT | {idname} + {tname}"
 
     def estimate(self):
+        """Estimate the TWFE model."""
         _fml = self._fml
         _data = self._data
 
@@ -47,7 +57,13 @@ class TWFE(DID):
 
     def vcov(self):
         """
-        Method not needed. The vcov matrix is calculated via the [Feols(/reference/Feols.qmd) object.
+        Variance-covariance matrix.
+
+        The vcov matrix is calculated via the [Feols(/reference/Feols.qmd) object.
+
+        Notes
+        -----
+        Method not needed.
         """
         pass
 
@@ -61,6 +77,7 @@ class TWFE(DID):
         title="TWFE Event Study Estimate",
         coord_flip=False,
     ):
+        """Plot TWFE estimates."""
         self.iplot(
             alpha=alpha,
             figsize=figsize,
@@ -71,8 +88,8 @@ class TWFE(DID):
             coord_flip=coord_flip,
         )
 
-    def tidy(self):
+    def tidy(self):  # noqa: D102
         return self.tidy()
 
-    def summary(self):
+    def summary(self):  # noqa: D102
         return self.summary()

--- a/pyfixest/estimation.py
+++ b/pyfixest/estimation.py
@@ -11,7 +11,7 @@ from pyfixest.utils import ssc
 
 def feols(
     fml: str,
-    data: DataFrameType,
+    data: DataFrameType,  # type: ignore
     vcov: Optional[Union[str, dict[str, str]]] = None,
     weights: Union[None, str] = None,
     ssc=ssc(),
@@ -27,46 +27,57 @@ def feols(
     Parameters
     ----------
     fml : str
-        A three-sided formula string using fixest formula syntax. Syntax: "Y ~ X1 + X2 | FE1 + FE2 | X1 ~ Z1". "|" separates dependent variable,
-        fixed effects, and instruments. Special syntax includes stepwise regressions, cumulative stepwise regression, multiple dependent variables,
+        A three-sided formula string using fixest formula syntax.
+        Syntax: "Y ~ X1 + X2 | FE1 + FE2 | X1 ~ Z1". "|" separates dependent variable,
+        fixed effects, and instruments. Special syntax includes stepwise regressions,
+        cumulative stepwise regression, multiple dependent variables,
         interaction of variables (i(X1,X2)), and interacted fixed effects (fe1^fe2).
 
     data : DataFrameType
         A pandas or polars dataframe containing the variables in the formula.
 
     vcov : Union[str, dict[str, str]]
-        Type of variance-covariance matrix for inference. Options include "iid", "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
+        Type of variance-covariance matrix for inference. Options include "iid",
+        "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
 
-    weights : Union[None, str], optional. Default is None. Weights for WLS estimation. If None, all observations are weighted equally. If a string, the name of the column in `data` that contains the weights.
+    weights : Union[None, str], optional.
+        Default is None. Weights for WLS estimation. If None, all observations
+        are weighted equally. If a string, the name of the column in `data` that
+        contains the weights.
 
     ssc : str
         A ssc object specifying the small sample correction for inference.
 
     fixef_rm : str
-        Specifies whether to drop singleton fixed effects. Options: "none" (default), "singleton".
+        Specifies whether to drop singleton fixed effects.
+        Options: "none" (default), "singleton".
 
     collin_tol : float, optional
-        Tolerance for collinearity check, by default 1e-06.
+        Tolerance for collinearity check, by default 1e-10.
 
     drop_intercept : bool, optional
         Whether to drop the intercept from the model, by default False.
 
     i_ref1 : Optional[Union[list, str]], optional
-        Reference category for the first set of categorical variables interacted via "i()", by default None.
+        Reference category for the first set of categorical variables interacted
+        via "i()", by default None.
 
     i_ref2 : Optional[Union[list, str]], optional
-        Reference category for the second set of categorical variables interacted via "i()", by default None.
+        Reference category for the second set of categorical variables interacted
+        via "i()", by default None.
 
     Returns
     -------
     object
-        An instance of the [Feols(/reference/Feols.qmd) class or `FixestMulti` class for multiple models specified via `fml`.
+        An instance of the [Feols(/reference/Feols.qmd) class or `FixestMulti`
+        class for multiple models specified via `fml`.
 
     Examples
     --------
-    As in `fixest`, the [Feols(/reference/Feols.qmd) function can be used to estimate a simple linear regression model with fixed effects.
-    The following example regresses `Y` on `X1` and `X2` with fixed effects for `f1` and `f2`: fixed effects are specified
-    after the `|` symbol.
+    As in `fixest`, the [Feols(/reference/Feols.qmd) function can be used to
+    estimate a simple linear regression model with fixed effects.
+    The following example regresses `Y` on `X1` and `X2` with fixed effects for
+    `f1` and `f2`: fixed effects are specified after the `|` symbol.
 
     ```{python}
     from pyfixest.estimation import feols
@@ -79,20 +90,26 @@ def feols(
     fit.summary()
     ```
 
-    Calling `feols()` returns an instance of the [Feols(/reference/Feols.qmd) class. The `summary()` method can be used to print the results.
+    Calling `feols()` returns an instance of the [Feols(/reference/Feols.qmd)
+    class. The `summary()` method can be used to print the results.
 
-    An alternative way to retrieve model results is via the `tidy()` method, which returns a pandas dataframe with the
-    estimated coefficients, standard errors, t-statistics, and p-values.
+    An alternative way to retrieve model results is via the `tidy()` method, which
+    returns a pandas dataframe with the estimated coefficients, standard errors,
+    t-statistics, and p-values.
 
     ```{python}
     fit.tidy()
     ```
 
-    You can also access all elements in the tidy data frame by dedicated methods, e.g. `fit.coef()` for the coefficients, `fit.se()` for the standard errors,
-    `fit.tstat()` for the t-statistics, and `fit.pval()` for the p-values, and `fit.confint()` for the confidence intervals.
+    You can also access all elements in the tidy data frame by dedicated methods,
+    e.g. `fit.coef()` for the coefficients, `fit.se()` for the standard errors,
+    `fit.tstat()` for the t-statistics, and `fit.pval()` for the p-values, and
+    `fit.confint()` for the confidence intervals.
 
-    The employed type of inference can be specified via the `vcov` argument. If vcov is not provided, `PyFixest` employs the `fixest` default of iid inference,
-    unless there are fixed effects in the model, in which case `feols()` clusters the standard error by the first fixed effect (CRV1 inference).
+    The employed type of inference can be specified via the `vcov` argument. If
+    vcov is not provided, `PyFixest` employs the `fixest` default of iid inference,
+    unless there are fixed effects in the model, in which case `feols()` clusters
+    the standard error by the first fixed effect (CRV1 inference).
 
     ```{python}
     fit1 = feols("Y ~ X1 + X2 | f1 + f2", data, vcov="iid")
@@ -100,9 +117,12 @@ def feols(
     fit3 = feols("Y ~ X1 + X2 | f1 + f2", data, vcov={"CRV1": "f1"})
     ```
 
-    Supported inference types are "iid", "hetero", "HC1", "HC2", "HC3", and "CRV1"/"CRV3". Clustered standard errors are specified via a dictionary, e.g. `{"CRV1": "f1"}`
-    for CRV1 inference with clustering by `f1` or `{"CRV3": "f1"}` for CRV3 inference with clustering by `f1`. For two-way clustering, you can provide a formula string, e.g.
-    `{"CRV1": "f1 + f2"}` for CRV1 inference with clustering by `f1`.
+    Supported inference types are "iid", "hetero", "HC1", "HC2", "HC3", and
+    "CRV1"/"CRV3". Clustered standard errors are specified via a dictionary,
+    e.g. `{"CRV1": "f1"}` for CRV1 inference with clustering by `f1` or
+    `{"CRV3": "f1"}` for CRV3 inference with clustering by `f1`. For two-way
+    clustering, you can provide a formula string, e.g. `{"CRV1": "f1 + f2"}` for
+    CRV1 inference with clustering by `f1`.
 
     ```{python}
     fit4 = feols("Y ~ X1 + X2 | f1 + f2", data, vcov={"CRV1": "f1 + f2"})
@@ -115,10 +135,13 @@ def feols(
     fit.vcov("iid").summary()
     ```
 
-    The `ssc` argument specifies the small sample correction for inference. In general, `feols()` uses all of `fixest::feols()` defaults, but sets the
-    `fixef.K` argument to `"none"` whereas the `fixest::feols()` default is `"nested"`. See here for more details: [link to github](https://github.com/s3alfisc/pyfixest/issues/260).
+    The `ssc` argument specifies the small sample correction for inference. In
+    general, `feols()` uses all of `fixest::feols()` defaults, but sets the
+    `fixef.K` argument to `"none"` whereas the `fixest::feols()` default is `"nested"`.
+    See here for more details: [link to github](https://github.com/s3alfisc/pyfixest/issues/260).
 
-    `feols()` supports a range of multiple estimation syntax, i.e. you can estimate multiple models in one call. The following example estimates two models, one with
+    `feols()` supports a range of multiple estimation syntax, i.e. you can estimate
+    multiple models in one call. The following example estimates two models, one with
     fixed effects for `f1` and one with fixed effects for `f2` using the `sw()` syntax.
 
     ```{python}
@@ -126,29 +149,34 @@ def feols(
     type(fit)
     ```
 
-    The returned object is an instance of the `FixestMulti` class. You can access the results of the first model via `fit.fetch_model(0)` and the results of the second model
-    via `fit.fetch_model(1)`. You can compare the model results via the `etable()` function:
+    The returned object is an instance of the `FixestMulti` class. You can access
+    the results of the first model via `fit.fetch_model(0)` and the results of
+    the second model via `fit.fetch_model(1)`. You can compare the model results
+    via the `etable()` function:
 
     ```{python}
     etable([fit.fetch_model(0), fit.fetch_model(1)])
     ```
 
-    Other supported multiple estimation syntax include `sw0()`, `csw()` and `csw0()`. While `sw()` adds variables in a "stepwise" fashinon, `csw()`
-    does so cumulatively.
+    Other supported multiple estimation syntax include `sw0()`, `csw()` and `csw0()`.
+    While `sw()` adds variables in a "stepwise" fashion, `csw()` does so cumulatively.
 
     ```{python}
     fit = feols("Y ~ X1 + X2 | csw(f1, f2)", data)
     etable([fit.fetch_model(0), fit.fetch_model(1)])
     ```
 
-    The `sw0()` and `csw0()` syntax are similar to `sw()` and `csw()`, but start with a model that exludes the variables specified in `sw()` and `csw()`:
+    The `sw0()` and `csw0()` syntax are similar to `sw()` and `csw()`, but start
+    with a model that excludes the variables specified in `sw()` and `csw()`:
 
     ```{python}
     fit = feols("Y ~ X1 + X2 | sw0(f1, f2)", data)
     etable([fit.fetch_model(0), fit.fetch_model(1), fit.fetch_model(2)])
     ```
 
-    The `feols()` function also supports multiple dependent variables. The following example estimates two models, one with `Y1` as the dependent variable and one with `Y2` as the dependent variable.
+    The `feols()` function also supports multiple dependent variables. The following
+    example estimates two models, one with `Y1` as the dependent variable and one
+    with `Y2` as the dependent variable.
 
     ```{python}
     fit = feols("Y + Y2 ~ X1 | f1 + f2", data)
@@ -159,11 +187,18 @@ def feols(
 
     ```{python}
     fit = feols("Y + Y2 ~ X1 | sw(f1, f2)", data)
-    etable([fit.fetch_model(0), fit.fetch_model(1), fit.fetch_model(2), fit.fetch_model(3)])
+    etable([fit.fetch_model(0),
+            fit.fetch_model(1),
+            fit.fetch_model(2),
+            fit.fetch_model(3)
+            ]
+        )
     ```
 
-    In general, using muliple estimation syntax can improve the estimation time as covariates that are demeaned in one model and are used
-    in another model do not need to be demeaned again: `feols()` implements a caching mechanism that stores the demeaned covariates.
+    In general, using muliple estimation syntax can improve the estimation time
+    as covariates that are demeaned in one model and are used in another model do
+    not need to be demeaned again: `feols()` implements a caching mechanism that
+    stores the demeaned covariates.
 
     Besides OLS, `feols()` also supports IV estimation via three part formulas:
 
@@ -171,24 +206,28 @@ def feols(
     fit = feols("Y ~  X2 | f1 + f2 | X1 ~ Z1", data)
     fit.tidy()
     ```
-    Here, `X1` is the endogenous variable and `Z1` is the instrument. `f1` and `f2` are the fixed effects, as before. To estimate
-    IV models without fixed effects, simply omit the fixed effects part of the formula:
+    Here, `X1` is the endogenous variable and `Z1` is the instrument. `f1` and `f2`
+    are the fixed effects, as before. To estimate IV models without fixed effects,
+    simply omit the fixed effects part of the formula:
 
     ```{python}
     fit = feols("Y ~  X2 | X1 ~ Z1", data)
     fit.tidy()
     ```
 
-    Last, `feols()` supports interaction of variables via the `i()` syntax. Documentation on this is tba.
+    Last, `feols()` supports interaction of variables via the `i()` syntax.
+    Documentation on this is tba.
 
-    After fitting a model via `feols()`, you can use the `predict()` method to get the predicted values:
+    After fitting a model via `feols()`, you can use the `predict()` method to
+    get the predicted values:
 
     ```{python}
     fit = feols("Y ~ X1 + X2 | f1 + f2", data)
     fit.predict()[0:5]
     ```
 
-    The `predict()` method also supports a `newdata` argument to predict on new data, which returns a numpy array of the predicted values:
+    The `predict()` method also supports a `newdata` argument to predict on new data,
+    which returns a numpy array of the predicted values:
 
     ```{python}
     fit = feols("Y ~ X1 + X2 | f1 + f2", data)
@@ -225,7 +264,7 @@ def feols(
 
 def fepois(
     fml: str,
-    data: DataFrameType,
+    data: DataFrameType,  # type: ignore
     vcov: Optional[Union[str, dict[str, str]]] = None,
     ssc=ssc(),
     fixef_rm: str = "none",
@@ -237,12 +276,14 @@ def fepois(
     i_ref2: Optional[Union[list, str]] = None,
 ) -> Union[Fepois, FixestMulti]:
     """
-    Estimate Poisson regression models with fixed effects using the `pplmhdfe` algorithm.
+    Estimate Poisson regression model with fixed effects using the `pplmhdfe` algorithm.
 
     Parameters
     ----------
     fml : str
-        A two-sided formula string using fixest formula syntax. Syntax: "Y ~ X1 + X2 | FE1 + FE2". "|" separates left-hand side and fixed effects.
+        A two-sided formula string using fixest formula syntax.
+        Syntax: "Y ~ X1 + X2 | FE1 + FE2". "|" separates left-hand side and fixed
+        effects.
         Special syntax includes:
         - Stepwise regressions (sw, sw0)
         - Cumulative stepwise regression (csw, csw0)
@@ -255,13 +296,15 @@ def fepois(
         A pandas or polars dataframe containing the variables in the formula.
 
     vcov : Union[str, dict[str, str]]
-        Type of variance-covariance matrix for inference. Options include "iid", "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
+        Type of variance-covariance matrix for inference. Options include "iid",
+        "hetero", "HC1", "HC2", "HC3", or a dictionary for CRV1/CRV3 inference.
 
     ssc : str
         A ssc object specifying the small sample correction for inference.
 
     fixef_rm : str
-        Specifies whether to drop singleton fixed effects. Options: "none" (default), "singleton".
+        Specifies whether to drop singleton fixed effects.
+        Options: "none" (default), "singleton".
 
     iwls_tol : Optional[float], optional
         Tolerance for IWLS convergence, by default 1e-08.
@@ -270,27 +313,31 @@ def fepois(
         Maximum number of iterations for IWLS convergence, by default 25.
 
     collin_tol : float, optional
-        Tolerance for collinearity check, by default 1e-06.
+        Tolerance for collinearity check, by default 1e-10.
 
     drop_intercept : bool, optional
         Whether to drop the intercept from the model, by default False.
 
     i_ref1 : Optional[Union[list, str]], optional
-        Reference category for the first set of categorical variables interacted via "i()", by default None.
+        Reference category for the first set of categorical variables interacted
+        via "i()", by default None.
 
     i_ref2 : Optional[Union[list, str]], optional
-        Reference category for the second set of categorical variables interacted via "i()", by default None.
+        Reference category for the second set of categorical variables interacted
+        via "i()", by default None.
 
     Returns
     -------
     object
-        An instance of the `Fepois` class or an instance of class `FixestMulti` for multiple models specified via `fml`.
+        An instance of the `Fepois` class or an instance of class `FixestMulti`
+        for multiple models specified via `fml`.
 
     Examples
     --------
-    The `fepois()` function can be used to estimate a simple Poisson regression model with fixed effects.
-    The following example regresses `Y` on `X1` and `X2` with fixed effects for `f1` and `f2`: fixed effects are specified
-    after the `|` symbol.
+    The `fepois()` function can be used to estimate a simple Poisson regression
+    model with fixed effects.
+    The following example regresses `Y` on `X1` and `X2` with fixed effects for
+    `f1` and `f2`: fixed effects are specified after the `|` symbol.
 
     ```{python}
     from pyfixest.estimation import fepois
@@ -301,7 +348,8 @@ def fepois(
     fit = fepois("Y ~ X1 + X2 | f1 + f2", data)
     fit.summary()
     ```
-    For more examples, please take a look at the documentation of the `feols()` function.
+    For more examples, please take a look at the documentation of the `feols()`
+    function.
     """
     assert i_ref2 is None, "The function argument i_ref2 is not yet supported."
 

--- a/pyfixest/exceptions.py
+++ b/pyfixest/exceptions.py
@@ -1,62 +1,62 @@
-class FixedEffectInteractionError(Exception):
+class FixedEffectInteractionError(Exception):  # noqa: D101
     pass
 
 
-class CovariateInteractionError(Exception):
+class CovariateInteractionError(Exception):  # noqa: D101
     pass
 
 
-class DuplicateKeyError(Exception):
+class DuplicateKeyError(Exception):  # noqa: D101
     pass
 
 
-class EndogVarsAsCovarsError(Exception):
+class EndogVarsAsCovarsError(Exception):  # noqa: D101
     pass
 
 
-class InstrumentsAsCovarsError(Exception):
+class InstrumentsAsCovarsError(Exception):  # noqa: D101
     pass
 
 
-class UnderDeterminedIVError(Exception):
+class UnderDeterminedIVError(Exception):  # noqa: D101
     pass
 
 
-class UnsupportedMultipleEstimationSyntax(Exception):
+class UnsupportedMultipleEstimationSyntax(Exception):  # noqa: D101
     pass
 
 
-class VcovTypeNotSupportedError(Exception):
+class VcovTypeNotSupportedError(Exception):  # noqa: D101
     pass
 
 
-class MultiEstNotSupportedError(Exception):
+class MultiEstNotSupportedError(Exception):  # noqa: D101
     pass
 
 
-class NanInClusterVarError(Exception):
+class NanInClusterVarError(Exception):  # noqa: D101
     pass
 
 
-class DepvarIsNotNumericError(Exception):
+class DepvarIsNotNumericError(Exception):  # noqa: D101
     pass
 
 
-class NotImplementedError(Exception):
+class NotImplementedError(Exception):  # noqa: D101
     pass
 
 
-class NonConvergenceError(Exception):
+class NonConvergenceError(Exception):  # noqa: D101
     pass
 
 
-class MatrixNotFullRankError(Exception):
+class MatrixNotFullRankError(Exception):  # noqa: D101
     pass
 
 
-class EmptyDesignMatrixError(Exception):
+class EmptyDesignMatrixError(Exception):  # noqa: D101
     pass
 
 
-class InvalidReferenceLevelError(Exception):
+class InvalidReferenceLevelError(Exception):  # noqa: D101
     pass

--- a/pyfixest/feiv.py
+++ b/pyfixest/feiv.py
@@ -122,6 +122,7 @@ class Feiv(Feols):
         self._support_iid_inference = True
 
     def get_fit(self) -> None:
+        """Fit a IV model using a 2SLS estimator."""
         _X = self._X
         _Z = self._Z
         _Y = self._Y

--- a/pyfixest/feols.py
+++ b/pyfixest/feols.py
@@ -204,8 +204,8 @@ class Feols:
         if self._has_weights or self._is_iv:
             self._supports_wildboottest = False
 
-        # attributes that have to be enriched outside of the class - not really optimal code
-        # change later
+        # attributes that have to be enriched outside of the class -
+        # not really optimal code change later
         self._data = None
         self._fml = None
         self._has_fixef = False
@@ -258,6 +258,13 @@ class Feols:
         self._adj_r2_within = None
 
     def get_fit(self) -> None:
+        """
+        Fit an OLS model.
+
+        Returns
+        -------
+        None
+        """
         _X = self._X
         _Y = self._Y
         _Z = self._Z
@@ -288,10 +295,13 @@ class Feols:
         Parameters
         ----------
         vcov : Union[str, dict[str, str]]
-            A string or dictionary specifying the type of variance-covariance matrix to use for inference.
-            If a string, it can be one of "iid", "hetero", "HC1", "HC2", "HC3". If a dictionary,
-            it should have the format {"CRV1": "clustervar"} for CRV1 inference or {"CRV3": "clustervar"}
-            for CRV3 inference. Note that CRV3 inference is currently not supported for IV estimation.
+            A string or dictionary specifying the type of variance-covariance matrix
+            to use for inference.
+            If a string, it can be one of "iid", "hetero", "HC1", "HC2", "HC3".
+            If a dictionary, it should have the format {"CRV1": "clustervar"} for
+            CRV1 inference or {"CRV3": "clustervar"}
+            for CRV3 inference. Note that CRV3 inference is currently not supported
+            for IV estimation.
 
         Returns
         -------
@@ -494,7 +504,7 @@ class Feols:
                         tXX = np.transpose(self._X) @ self._X
                         tXy = np.transpose(self._X) @ self._Y
 
-                        # compute leave-one-out regression coefficients (aka clusterjacks')
+                        # compute leave-one-out regression coefficients (aka clusterjacks')  # noqa: W505
                         for ixg, g in enumerate(clustid):
                             Xg = self._X[np.equal(g, cluster_col)]
                             Yg = self._Y[np.equal(g, cluster_col)]
@@ -587,7 +597,10 @@ class Feols:
         na_index: np.ndarray,
     ) -> None:
         """
-        Enrich an instance of class [Feols(/reference/Feols.qmd) with additional attributes set in the `FixestMulti` class.
+        Enrich Feols object.
+
+        Enrich an instance of `Feols` Class with additional
+        attributes set in the `FixestMulti` class.
 
         Parameters
         ----------
@@ -628,17 +641,22 @@ class Feols:
 
     def wald_test(self, R=None, q=None, distribution="F") -> None:
         """
-        Compute a Wald test for a linear hypothesis of the form Rb = q. By default, tests the joint null
-        hypothesis that all coefficients are zero.
+        Conduct Wald test.
+
+        Compute a Wald test for a linear hypothesis of the form Rb = q.
+        By default, tests the joint null hypothesis that all coefficients are zero.
 
         Parameters
         ----------
         R : array-like, optional
-            The matrix R of the linear hypothesis. If None, defaults to an identity matrix.
+            The matrix R of the linear hypothesis.
+            If None, defaults to an identity matrix.
         q : array-like, optional
-            The vector q of the linear hypothesis. If None, defaults to a vector of zeros.
+            The vector q of the linear hypothesis.
+            If None, defaults to a vector of zeros.
         distribution : str, optional
-            The distribution to use for the p-value. Can be either "F" or "chi2". Defaults to "F".
+            The distribution to use for the p-value. Can be either "F" or "chi2".
+            Defaults to "F".
 
         Returns
         -------
@@ -723,7 +741,8 @@ class Feols:
         Parameters
         ----------
         alpha : float, optional
-            Significance level for highlighting significant coefficients. Defaults to None.
+            Significance level for highlighting significant coefficients.
+            Defaults to None.
         figsize : tuple[int, int], optional
             Size of the plot (width, height) in inches. Defaults to None.
         yintercept : float, optional
@@ -733,7 +752,8 @@ class Feols:
         rotate_xticks : int, optional
             Rotation angle for x-axis tick labels. Defaults to None.
         coefficients : list[str], optional
-            List of coefficients to include in the plot. If None, all coefficients are included.
+            List of coefficients to include in the plot.
+            If None, all coefficients are included.
         title : str, optional
             Title of the plot. Defaults to None.
         coord_flip : bool, optional
@@ -778,19 +798,19 @@ class Feols:
         Parameters
         ----------
         alpha : float, optional
-            Significance level for visualization options. Defaults to None.
+            Significance level for visualization options. Defaults to 0.05.
         figsize : tuple[int, int], optional
-            Size of the plot (width, height) in inches. Defaults to None.
+            Size of the plot (width, height) in inches. Defaults to (500, 300).
         yintercept : float, optional
             Value to set as the y-axis intercept (vertical line). Defaults to None.
         xintercept : float, optional
             Value to set as the x-axis intercept (horizontal line). Defaults to None.
         rotate_xticks : int, optional
-            Rotation angle for x-axis tick labels. Defaults to None.
+            Rotation angle for x-axis tick labels. Defaults to 0.
         title : str, optional
             Title of the plot. Defaults to None.
         coord_flip : bool, optional
-            Whether to flip the coordinates of the plot. Defaults to None.
+            Whether to flip the coordinates of the plot. Defaults to True.
 
         Returns
         -------
@@ -835,37 +855,48 @@ class Feols:
         B : int
             The number of bootstrap iterations to run.
         cluster : Union[None, np.ndarray, pd.Series, pd.DataFrame], optional
-            If None (default), checks if the model's vcov type was CRV. If yes, uses `self._clustervar`
-            as cluster. If None and no clustering was employed in the initial model, runs a heteroskedastic
-            wild bootstrap. If an argument is supplied, it is used as the cluster variable for the wild cluster
-            bootstrap. Requires a numpy array of dimension one, a pandas Series, or DataFrame, containing the clustering variable.
+            If None (default), checks if the model's vcov type was CRV.
+            If yes, uses `self._clustervar` as cluster. If None and no clustering
+            was employed in the initial model, runs a heteroskedastic wild bootstrap.
+            If an argument is supplied, it is used as the cluster variable for the
+            wild cluster bootstrap. Requires a numpy array of dimension one, a
+            pandas Series, or DataFrame, containing the clustering variable.
         param : Union[str, None], optional
-            A string of length one, containing the test parameter of interest. Defaults to None.
+            A string of length one, containing the test parameter of interest.
+            Defaults to None.
         weights_type : str, optional
-            The type of bootstrap weights. Options are 'rademacher', 'mammen', 'webb', or 'normal'. Defaults to 'rademacher'.
+            The type of bootstrap weights. Options are 'rademacher', 'mammen',
+            'webb', or 'normal'. Defaults to 'rademacher'.
         impose_null : bool, optional
-            Indicates whether to impose the null hypothesis on the bootstrap DGP. Defaults to True.
+            Indicates whether to impose the null hypothesis on the bootstrap DGP.
+            Defaults to True.
         bootstrap_type : str, optional
-            A string of length one to choose the bootstrap type. Options are '11', '31', '13', or '33'. Defaults to '11'.
+            A string of length one to choose the bootstrap type.
+            Options are '11', '31', '13', or '33'. Defaults to '11'.
         seed : Union[int, None], optional
             An option to provide a random seed. Defaults to None.
         adj : bool, optional
-            Indicates whether to apply a small sample adjustment for the number of observations and covariates. Defaults to True.
+            Indicates whether to apply a small sample adjustment for the number
+            of observations and covariates. Defaults to True.
         cluster_adj : bool, optional
-            Indicates whether to apply a small sample adjustment for the number of clusters. Defaults to True.
+            Indicates whether to apply a small sample adjustment for the number
+            of clusters. Defaults to True.
         parallel : bool, optional
             Indicates whether to run the bootstrap in parallel. Defaults to False.
         seed : Union[str, None], optional
             An option to provide a random seed. Defaults to None.
         return_bootstrapped_t_stats : bool, optional:
-            If True, the method returns a tuple of the regular output and the bootstrapped t-stats. Defaults to False.
+            If True, the method returns a tuple of the regular output and the
+            bootstrapped t-stats. Defaults to False.
 
         Returns
         -------
         pd.DataFrame
-            A DataFrame with the original, non-bootstrapped t-statistic and bootstrapped p-value, along with
-            the bootstrap type, inference type (HC vs CRV), and whether the null hypothesis was imposed on the bootstrap DGP.
-            If `return_bootstrapped_t_stats` is True, the method returns a tuple of the regular output and the bootstrapped t-stats.
+            A DataFrame with the original, non-bootstrapped t-statistic and
+            bootstrapped p-value, along with the bootstrap type, inference type
+            (HC vs CRV), and whether the null hypothesis was imposed on the
+            bootstrap DGP. If `return_bootstrapped_t_stats` is True, the method
+            returns a tuple of the regular output and the bootstrapped t-stats.
         """
         _is_iv = self._is_iv
         _has_fixef = self._has_fixef
@@ -1003,7 +1034,8 @@ class Feols:
 
         This method creates the following attributes:
         - `alphaDF` (pd.DataFrame): A DataFrame with the estimated fixed effects.
-        - `sumFE` (np.array): An array with the sum of fixed effects for each observation (i = 1, ..., N).
+        - `sumFE` (np.array): An array with the sum of fixed effects for each
+        observation (i = 1, ..., N).
 
         Returns
         -------
@@ -1075,11 +1107,13 @@ class Feols:
 
         return self._fixef_dict
 
-    def predict(self, newdata: Optional[DataFrameType] = None) -> np.ndarray:
+    def predict(self, newdata: Optional[DataFrameType] = None) -> np.ndarray:  # type: ignore
         """
+        Predict values of the model on new data.
+
         Return a flat np.array with predicted values of the regression model.
-        If new fixed effect levels are introduced in `newdata`, predicted values for such observations
-        will be set to NaN.
+        If new fixed effect levels are introduced in `newdata`, predicted values
+        for such observations will be set to NaN.
 
         Parameters
         ----------
@@ -1132,7 +1166,7 @@ class Feols:
                     ]  # as variables are called C(var) in the fixef_dict
 
                     for level in new_levels:
-                        # if level estimated: either estimated value (or 0 for reference level)
+                        # if level estimated: either estimated value (or 0 for reference level)  # noqa: W505
                         if level in old_levels:
                             fixef_mat[df_fe[fixef] == level, i] = subdict.get(level, 0)
                         # if new level not estimated: set to NaN
@@ -1175,10 +1209,12 @@ class Feols:
 
     def get_performance(self) -> None:
         """
-        Compute multiple additional measures commonly reported with linear regression output,
-        including R-squared and adjusted R-squared. Note that variables with the suffix _within
-        use demeaned dependent variables Y, while variables without do not or are invariant to
-        demeaning.
+        Get Goodness-of-Fit measures.
+
+        Compute multiple additional measures commonly reported with linear
+        regression output, including R-squared and adjusted R-squared. Note that
+        variables with the suffix _within use demeaned dependent variables Y,
+        while variables without do not or are invariant to demeaning.
 
         Returns
         -------
@@ -1187,8 +1223,10 @@ class Feols:
         Creates the following instances:
         - r2 (float): R-squared of the regression model.
         - adj_r2 (float): Adjusted R-squared of the regression model.
-        - r2_within (float): R-squared of the regression model, computed on demeaned dependent variable.
-        - adj_r2_within (float): Adjusted R-squared of the regression model, computed on demeaned dependent variable.
+        - r2_within (float): R-squared of the regression model, computed on
+        demeaned dependent variable.
+        - adj_r2_within (float): Adjusted R-squared of the regression model,
+        computed on demeaned dependent variable.
         """
         _Y_within = self._Y
         _Y = self._Y_untransformed.values
@@ -1233,13 +1271,16 @@ class Feols:
 
     def tidy(self) -> pd.DataFrame:
         """
-        Return a tidy pd.DataFrame with the point estimates, standard errors, t statistics, and p-values.
+        Tidy model outputs.
+
+        Return a tidy pd.DataFrame with the point estimates, standard errors,
+        t-statistics, and p-values.
 
         Returns
         -------
         tidy_df : pd.DataFrame
-            A tidy pd.DataFrame containing the regression results, including point estimates, standard errors,
-            t statistics, and p-values.
+            A tidy pd.DataFrame containing the regression results, including point
+            estimates, standard errors, t-statistics, and p-values.
         """
         _coefnames = self._coefnames
         _se = self._se
@@ -1264,6 +1305,8 @@ class Feols:
 
     def coef(self) -> pd.Series:
         """
+        Fitted model coefficents.
+
         Returns
         -------
         pd.Series
@@ -1273,6 +1316,8 @@ class Feols:
 
     def se(self) -> pd.Series:
         """
+        Fitted model standard errors.
+
         Returns
         -------
         pd.Series
@@ -1282,6 +1327,8 @@ class Feols:
 
     def tstat(self) -> pd.Series:
         """
+        Fitted model t-statistics.
+
         Returns
         -------
         pd.Series
@@ -1291,6 +1338,8 @@ class Feols:
 
     def pvalue(self) -> pd.Series:
         """
+        Fitted model p-values.
+
         Returns
         -------
         pd.Series
@@ -1300,6 +1349,8 @@ class Feols:
 
     def confint(self) -> pd.DataFrame:
         """
+        Fitted model confidence intervals.
+
         Returns
         -------
         pd.DataFrame
@@ -1309,6 +1360,8 @@ class Feols:
 
     def resid(self) -> np.ndarray:
         """
+        Fitted model residuals.
+
         Returns
         -------
         np.ndarray
@@ -1318,6 +1371,8 @@ class Feols:
 
     def summary(self, digits=3) -> None:
         """
+        Summary of estimated model.
+
         Parameters
         ----------
         digits : int, optional
@@ -1398,7 +1453,8 @@ def _deparse_vcov_input(vcov, has_fixef, is_iv):
     vcov_type : str
         The type of vcov to be used. Either "iid", "hetero", or "CRV".
     vcov_type_detail : str or list
-        The type of vcov to be used, with more detail. Options include "iid", "hetero", "HC1", "HC2", "HC3", "CRV1", or "CRV3".
+        The type of vcov to be used, with more detail. Options include "iid",
+        "hetero", "HC1", "HC2", "HC3", "CRV1", or "CRV3".
     is_clustered : bool
         Indicates whether the vcov is clustered.
     clustervar : str
@@ -1471,7 +1527,10 @@ def _feols_input_checks(Y, X, weights):
 
 def _get_vcov_type(vcov, fval):
     """
-    Passes the specified vcov type and sets the default vcov type based on the inclusion of fixed effects in the model.
+    Get variance-covariance matrix type.
+
+    Passes the specified vcov type and sets the default vcov type based on the
+    inclusion of fixed effects in the model.
 
     Parameters
     ----------
@@ -1483,8 +1542,9 @@ def _get_vcov_type(vcov, fval):
     Returns
     -------
     vcov_type : str
-        The specified or default vcov type. Defaults to 'iid' if no fixed effect is included in the model,
-        and 'CRV1' clustered by the first fixed effect if a fixed effect is included.
+        The specified or default vcov type. Defaults to 'iid' if no fixed effect
+        is included in the model, and 'CRV1' clustered by the first fixed effect
+        if a fixed effect is included.
     """
     if vcov is None:
         # iid if no fixed effects
@@ -1504,7 +1564,7 @@ def _drop_multicollinear_variables(
     X: np.ndarray, names: list[str], collin_tol: float
 ) -> None:
     """
-    Checks for multicollinearity in the design matrices X and Z.
+    Check for multicollinearity in the design matrices X and Z.
 
     Parameters
     ----------
@@ -1561,8 +1621,10 @@ def _drop_multicollinear_variables(
 
 def _find_collinear_variables(X, tol=1e-10):
     """
-    Detect multicollinear variables, replicating Laurent Berge's C++ implementation from the fixest package.
-    See the fixest repo [here](https://github.com/lrberge/fixest/blob/a4d1a9bea20aa7ab7ab0e0f1d2047d8097971ad7/src/lm_related.cpp#L130)
+    Detect multicollinear variables.
+
+    Detect multicollinear variables, replicating Laurent Berge's C++ implementation
+    from the fixest package. See the fixest repo [here](https://github.com/lrberge/fixest/blob/a4d1a9bea20aa7ab7ab0e0f1d2047d8097971ad7/src/lm_related.cpp#L130)
 
     Parameters
     ----------
@@ -1575,7 +1637,8 @@ def _find_collinear_variables(X, tol=1e-10):
     -------
     res : dict
         A dictionary containing:
-        - id_excl (numpy.ndarray): A boolean array, where True indicates a collinear variable.
+        - id_excl (numpy.ndarray): A boolean array, where True indicates a collinear
+        variable.
         - n_excl (int): The number of collinear variables.
         - all_removed (bool): True if all variables are identified as collinear.
     """
@@ -1627,6 +1690,31 @@ def _find_collinear_variables(X, tol=1e-10):
 # CODE from Styfen Schaer (@styfenschaer)
 @nb.njit(parallel=False)
 def bucket_argsort(arr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Sorts the input array using the bucket sort algorithm.
+
+    Parameters
+    ----------
+    arr : array_like
+        An array_like object that needs to be sorted.
+
+    Returns
+    -------
+    array_like
+        A sorted copy of the input array.
+
+    Raises
+    ------
+    ValueError
+        If the input is not an array_like object.
+
+    Notes
+    -----
+    The bucket sort algorithm works by distributing the elements of an array
+    into a number of buckets. Each bucket is then sorted individually, either
+    using a different sorting algorithm, or by recursively applying the bucket
+    sorting algorithm.
+    """
     counts = np.zeros(arr.max() + 1, dtype=np.uint32)
     for i in range(arr.size):
         counts[arr[i]] += 1

--- a/pyfixest/fepois.py
+++ b/pyfixest/fepois.py
@@ -14,18 +14,20 @@ from pyfixest.feols import Feols
 
 class Fepois(Feols):
     """
-    Non user-facing class to estimate a Poisson regression model via Iterated Weighted Least Squares (IWLS).
+    Estimate a Poisson regression model.
+
+    Non user-facing class to estimate a Poisson regression model via Iterated
+    Weighted Least Squares (IWLS).
 
     Inherits from the Feols class. Users should not directly instantiate this class,
-    but rather use the [fepois()](/reference/estimation.fepois.qmd) function. Note that
-    no demeaning is performed in this class: demeaning is performed in the
+    but rather use the [fepois()](/reference/estimation.fepois.qmd) function.
+    Note that no demeaning is performed in this class: demeaning is performed in the
     [FixestMulti](/reference/estimation.fixest_multi.qmd) class (to allow for caching
     of demeaned variables for multiple estimation).
 
     The method implements the algorithm from Stata's `pplmhdfe` module.
 
-
-    Parameters
+    Attributes
     ----------
     Y : np.ndarray
         Dependent variable, a two-dimensional numpy array.
@@ -120,11 +122,14 @@ class Fepois(Feols):
         weights : np.ndarray
             Weights (from the last iteration of the IRLS algorithm).
         X : np.ndarray
-            Demeaned independent variables (from the last iteration of the IRLS algorithm).
+            Demeaned independent variables (from the last iteration of the IRLS
+            algorithm).
         Z : np.ndarray
-            Demeaned independent variables (from the last iteration of the IRLS algorithm).
+            Demeaned independent variables (from the last iteration of the IRLS
+            algorithm).
         Y : np.ndarray
-            Demeaned dependent variable (from the last iteration of the IRLS algorithm).
+            Demeaned dependent variable (from the last iteration of the IRLS
+            algorithm).
         """
         _Y = self._Y
         _X = self._X
@@ -155,7 +160,10 @@ class Fepois(Feols):
                 break
             if i == _maxiter:
                 raise NonConvergenceError(
-                    f"The IRLS algorithm did not converge with {_iwls_maxiter} iterations. Try to increase the maximum number of iterations."
+                    f"""
+                    The IRLS algorithm did not converge with {_iwls_maxiter}
+                    iterations. Try to increase the maximum number of iterations.
+                    """
                 )
 
             if i == 0:
@@ -256,7 +264,8 @@ class Fepois(Feols):
         Return predicted values from regression model.
 
         Return a flat np.array with predicted values of the regression model.
-        If new fixed effect levels are introduced in `newdata`, predicted values for such observations
+        If new fixed effect levels are introduced in `newdata`, predicted values
+        for such observations
         will be set to NaN.
 
         Parameters
@@ -265,9 +274,12 @@ class Fepois(Feols):
             A pd.DataFrame with the new data, to be used for prediction.
             If None (default), uses the data used for fitting the model.
         type : str, optional
-            The type of prediction to be computed. Can be either "response" (default) or "link".
-            If type="response", the output is at the level of the response variable, i.e., it is the expected predictor E(Y|X).
-            If "link", the output is at the level of the explanatory variables, i.e., the linear predictor X @ beta.
+            The type of prediction to be computed.
+            Can be either "response" (default) or "link".
+            If type="response", the output is at the level of the response variable,
+            i.e., it is the expected predictor E(Y|X).
+            If "link", the output is at the level of the explanatory variables,
+            i.e., the linear predictor X @ beta.
 
         Returns
         -------
@@ -300,8 +312,8 @@ def _check_for_separation(Y: pd.DataFrame, fe: pd.DataFrame, check: str = "fe") 
     """
     Check for separation.
 
-    Check for separation of Poisson Regression. For details, see the pplmhdfe documentation on
-    separation checks. Currently, only the "fe" check is implemented.
+    Check for separation of Poisson Regression. For details, see the pplmhdfe
+    documentation on separation checks. Currently, only the "fe" check is implemented.
 
     Parameters
     ----------

--- a/pyfixest/model_matrix_fixest.py
+++ b/pyfixest/model_matrix_fixest.py
@@ -50,8 +50,9 @@ def model_matrix_fixest(
     data : pd.DataFrame
         The input DataFrame containing the data.
     drop_intercept : bool
-        Whether to drop the intercept from the model matrix. Default is False. If True, the intercept is dropped ex post from the model matrix
-        created by formulaic.
+        Whether to drop the intercept from the model matrix. Default is False.
+        If True, the intercept is dropped ex post from the model matrix created
+        by formulaic.
     i_ref1 : str or list
         The reference level for the first variable in the i() syntax.
     i_ref2 : str or list
@@ -64,30 +65,38 @@ def model_matrix_fixest(
         - Y : pd.DataFrame
             A DataFrame of the dependent variable.
         - X : pd.DataFrame
-            A DataFrame of the covariates. If `combine = True`, contains covariates and fixed effects as dummies.
+            A DataFrame of the covariates. If `combine = True`, contains covariates
+            and fixed effects as dummies.
         - I : Optional[pd.DataFrame]
             A DataFrame of the Instruments, None if no IV.
         - fe : Optional[pd.DataFrame]
-            A DataFrame of the fixed effects, None if no fixed effects specified. Only applicable if `combine = False`.
+            A DataFrame of the fixed effects, None if no fixed effects specified.
+            Only applicable if `combine = False`.
         - na_index : np.array
             An array with indices of dropped columns.
         - fe_na : np.array
-            An array with indices of dropped columns due to fixed effect singletons or NaNs in the fixed effects.
+            An array with indices of dropped columns due to fixed effect singletons
+            or NaNs in the fixed effects.
         - na_index_str : str
-            na_index, but as a comma-separated string. Used for caching of demeaned variables.
+            na_index, but as a comma-separated string. Used for caching of demeaned
+            variables.
         - z_names : Optional[list[str]]
-            Names of all covariates, minus the endogenous variables, plus the instruments. None if no IV.
+            Names of all covariates, minus the endogenous variables,
+            plus the instruments.
+            None if no IV.
         - weights : Optional[str]
             Weights as a string if provided, or None if no weights, e.g., "weights".
         - has_weights : bool
             A boolean indicating whether weights are used.
         - icovars : Optional[list[str]]
-            A list of interaction variables provided via `i()`. None if no interaction variables via `i()` provided.
+            A list of interaction variables provided via `i()`. None if no interaction
+            variables via `i()` provided.
 
     Attributes
     ----------
     list or None
-        icovars - A list of interaction variables. None if no interaction variables via `i()` provided.
+        icovars - A list of interaction variables. None if no interaction variables
+        via `i()` provided.
     """
     # check if weights are valid
     _check_weights(weights, data)
@@ -112,15 +121,17 @@ def model_matrix_fixest(
         is_ivar = _find_ivars(x)
         # if yes:
         if is_ivar[1]:
-            # if a reference level i_ref1 is set: code contrast as C(var, contr.treatment(base=i_ref1[0]))
+            # if a reference level i_ref1 is set: code contrast as
+            # C(var, contr.treatment(base=i_ref1[0]))
             # if no reference level is set: code contrast as C(var)
             if i_ref1:
                 inner_C = f"C({_ivars[0]},contr.treatment(base={i_ref1[0]}))"
             else:
                 inner_C = f"C({_ivars[0]})"
 
-            # if there is a second variable interacted via i() syntax, i.e. i(var1, var2),
-            # then code contrast as C(var1, contr.treatment(base=i_ref1[0])):var2, where var2 = i_ref2[1]
+            # if there is a second variable interacted via i() syntax,
+            # i.e. i(var1, var2), then code contrast as
+            # C(var1, contr.treatment(base=i_ref1[0])):var2, where var2 = i_ref2[1]
             if len(_ivars) == 2:
                 interact_vars = f"{inner_C}:{_ivars[1]}"
             elif len(_ivars) == 1:
@@ -168,7 +179,9 @@ def model_matrix_fixest(
 
     Y, X = model_matrix(fml_exog, data)
 
-    X_is_empty = False  # special case: sometimes it is useful to run models "Y ~ 0 | f1" to demean Y + to use the predict method
+    # special case: sometimes it is useful to run models "Y ~ 0 | f1"
+    # to demean Y + to use the predict method
+    X_is_empty = False
     if X.shape[1] == 0:
         X_is_empty = True
 
@@ -374,7 +387,8 @@ def _clean_fe(data: pd.DataFrame, fval: str) -> tuple[pd.DataFrame, list[int]]:
 
     This is a helper function used in `_model_matrix_fixest()`. The function converts
     the fixed effects to integers and marks fixed effects with NaNs. It's important
-    to note that NaNs are not removed at this stage; this is done in `_model_matrix_fixest()`.
+    to note that NaNs are not removed at this stage; this is done in
+    `_model_matrix_fixest()`.
 
     Parameters
     ----------
@@ -420,7 +434,10 @@ def _clean_fe(data: pd.DataFrame, fval: str) -> tuple[pd.DataFrame, list[int]]:
 
 def _get_icovars(_ivars: list[str], X: pd.DataFrame) -> Optional[list[str]]:
     """
-    Get all interacted variables via i() syntax. Required for plotting of all interacted variables via iplot().
+    Get interacted variables.
+
+    Get all interacted variables via i() syntax. Required for plotting of all
+    interacted variables via iplot().
 
     Parameters
     ----------
@@ -454,7 +471,10 @@ def _get_icovars(_ivars: list[str], X: pd.DataFrame) -> Optional[list[str]]:
 
 def _check_i_refs2(ivars, i_ref1, i_ref2, data) -> None:
     """
-    Check if the reference level have the same type as the variable (if not, string matching might fail).
+    Check reference levels.
+
+    Check if the reference level have the same type as the variable
+    (if not, string matching might fail).
 
     Parameters
     ----------
@@ -477,7 +497,8 @@ def _check_i_refs2(ivars, i_ref1, i_ref2, data) -> None:
             ivar2 = ivars[1]
 
         if i_ref1:
-            # check that the type of each value in i_ref1 is the same as the type of the variable
+            # check that the type of each value in i_ref1 is the same as the
+            # type of the variable
             ivar1_col = data[ivar1]
             for i in i_ref1:
                 if pd.api.types.is_integer_dtype(ivar1_col) and not isinstance(i, int):
@@ -503,7 +524,10 @@ def _check_i_refs2(ivars, i_ref1, i_ref2, data) -> None:
 
 def _get_i_refs_to_drop(_ivars, i_ref1, i_ref2, X):
     """
-    Collect all variables that (still) need to be dropped as reference levels from the model matrix.
+    Identify reference levels to drop.
+
+    Collect all variables that (still) need to be dropped as reference levels
+    from the model matrix.
 
     Parameters
     ----------
@@ -521,7 +545,8 @@ def _get_i_refs_to_drop(_ivars, i_ref1, i_ref2, X):
     # now drop reference levels / variables before collecting variable names
     if _ivars:
         if i_ref1:
-            # different logic for one vs two interaction variables in i() due to how contr.treatment() works
+            # different logic for one vs two interaction variables in i() due
+            # to how contr.treatment() works
             if len(_ivars) == 1:
                 if len(i_ref1) == 1:
                     pass  # do nothing, reference level already dropped via contr.treatment()
@@ -559,6 +584,7 @@ def _get_i_refs_to_drop(_ivars, i_ref1, i_ref2, X):
 def _is_numeric(column):
     """
     Check if a column is numeric.
+
     Args:
         column: pd.Series
             A pandas Series.
@@ -577,9 +603,12 @@ def _is_numeric(column):
 
 def _check_weights(weights, data):
     """
+    Check if valid weights are in data.
+
     Args:
         weights: str or None
-            A string specifying the name of the weights column in `data`. Default is None.
+            A string specifying the name of the weights column in `data`.
+            Default is None.
         data: pd.DataFrame
             The input DataFrame containing the data.
 
@@ -605,9 +634,7 @@ def _check_weights(weights, data):
 
 
 def _is_finite_positive(x: Union[pd.DataFrame, pd.Series, np.ndarray]):
-    """
-    Check if a column is finite and positive.
-    """
+    """Check if a column is finite and positive."""
     if isinstance(x, (pd.DataFrame, pd.Series)):
         x = x.to_numpy()
 

--- a/pyfixest/multcomp.py
+++ b/pyfixest/multcomp.py
@@ -42,7 +42,6 @@ def bonferroni(models: Union[list[Feols, Fepois], Fepois], param: str) -> pd.Dat
     bonf_df
     ```
     """
-
     models = _post_processing_input_checks(models)
     all_model_stats = pd.DataFrame()
     S = len(models)

--- a/pyfixest/multcomp.py
+++ b/pyfixest/multcomp.py
@@ -19,14 +19,16 @@ def bonferroni(models: Union[list[Feols, Fepois], Fepois], param: str) -> pd.Dat
     Parameters
     ----------
     models : list[Feols, Fepois], Feols or Fepois
-        A list of models for which the p-values should be adjusted, or a Feols or Fepois object.
+        A list of models for which the p-values should be adjusted, or a Feols or
+        Fepois object.
     param : str
         The parameter for which the p-values should be adjusted.
 
     Returns
     -------
     pd.DataFrame
-        A DataFrame containing estimation statistics, including the Bonferroni adjusted p-values.
+        A DataFrame containing estimation statistics, including the Bonferroni
+        adjusted p-values.
 
     Examples
     --------
@@ -38,7 +40,7 @@ def bonferroni(models: Union[list[Feols, Fepois], Fepois], param: str) -> pd.Dat
     data = get_data().dropna()
     fit1 = feols("Y ~ X1", data=data)
     fit2 = feols("Y ~ X1 + X2", data=data)
-    bonf_df = bonferroni([fit1, fit2], param = "X1")
+    bonf_df = bonferroni([fit1, fit2], param="X1")
     bonf_df
     ```
     """
@@ -69,13 +71,14 @@ def rwolf(
     Compute Romano-Wolf adjusted p-values for multiple hypothesis testing.
 
     For each model, it is assumed that tests to adjust are of the form
-    "param = 0". This function uses the `wildboottest()` method for running the bootstrap,
-    hence models of type `Feiv` or `Fepois` are not supported.
+    "param = 0". This function uses the `wildboottest()` method for running the
+    bootstrap, hence models of type `Feiv` or `Fepois` are not supported.
 
     Parameters
     ----------
     models : list[Feols] or FixestMulti
-        A list of models for which the p-values should be computed, or a FixestMulti object.
+        A list of models for which the p-values should be computed, or a
+        FixestMulti object.
         Models of type `Feiv` or `Fepois` are not supported.
     param : str
         The parameter for which the p-values should be computed.
@@ -87,7 +90,8 @@ def rwolf(
     Returns
     -------
     pd.DataFrame
-        A DataFrame containing estimation statistics, including the Romano-Wolf adjusted p-values.
+        A DataFrame containing estimation statistics, including the Romano-Wolf
+        adjusted p-values.
 
     Examples
     --------
@@ -151,10 +155,10 @@ def _get_rwolf_pval(t_stats, boot_t_stats):
     Parameters
     ----------
     t_stats (np.ndarray): A vector of length S - where S is the number of
-                          tested hypotheses - containing the original,
-                          non-bootstrappe t-statisics.
+                        tested hypotheses - containing the original,
+                        non-bootstrappe t-statisics.
     boot_t_stats (np.ndarray): A (B x S) matrix containing the
-                               bootstrapped t-statistics.
+                            bootstrapped t-statistics.
 
     Returns
     -------

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -27,11 +27,14 @@ def etable(
     digits : int
         Number of digits to round to.
     type : str, optional
-        Type of output. Either "df" for pandas DataFrame, "md" for markdown, or "tex" for LaTeX table. Default is "md".
+        Type of output. Either "df" for pandas DataFrame, "md" for markdown,
+        or "tex" for LaTeX table. Default is "md".
     signif_code : list, optional
-        Significance levels for the stars. Default is [0.001, 0.01, 0.05]. If None, no stars are printed.
+        Significance levels for the stars. Default is [0.001, 0.01, 0.05].
+        If None, no stars are printed.
     coef_fmt : str, optional
-        The format of the coefficient (b), standard error (se), t-stats (t), and p-value (p). Default is `"b (se)"`.
+        The format of the coefficient (b), standard error (se), t-stats (t), and
+        p-value (p). Default is `"b (se)"`.
         Spaces ` `, parentheses `()`, brackets `[]`, newlines `\n` are supported.
         Newline is not support for LaTeX output.
 
@@ -39,7 +42,7 @@ def etable(
     -------
     pandas.DataFrame
         A DataFrame with the coefficients and standard errors of the models.
-    """
+    """  # noqa: D301
     assert (
         signif_code is None or len(signif_code) == 3
     ), "signif_code must be a list of length 3 or None"
@@ -188,7 +191,7 @@ def summary(
     models: Union[Feols, Fepois, Feiv, list], digits: Optional[int] = 3
 ) -> None:
     """
-    Prints a summary of estimation results for each estimated model.
+    Print a summary of estimation results for each estimated model.
 
     For each model, this method prints a header indicating the fixed-effects and the
     dependent variable, followed by a table of coefficient estimates with standard
@@ -292,8 +295,10 @@ def _post_processing_input_checks(models):
                 if not isinstance(model, (Feols, Fepois)):
                     raise TypeError(
                         f"""
-                            Each element of the passed list needs to be of type Feols or Fepois, but {type(model)} was passed.
-                            If you want to summarize a FixestMulti object, please use FixestMulti.to_list() to convert it to a list of Feols or Fepois instances.
+                        Each element of the passed list needs to be of type Feols
+                        or Fepois, but {type(model)} was passed. If you want to
+                        summarize a FixestMulti object, please use FixestMulti.to_list()
+                        to convert it to a list of Feols or Fepois instances.
                         """
                     )
 

--- a/pyfixest/utils.py
+++ b/pyfixest/utils.py
@@ -9,14 +9,18 @@ def ssc(adj=True, fixef_k="none", cluster_adj=True, cluster_df="min"):
 
     Parameters
     ----------
-        adj: bool, default True
-            If True, applies a small sample correction of (N-1) / (N-k) where N is the number of observations
-            and k is the number of estimated coefficients excluding any fixed effects projected out in either fixest::feols() or lfe::felm().
-        fixef_k: str, default "none"
-            Equal to 'none': the fixed effects parameters are discarded when calculating k in (N-1) / (N-k).
-        cluster_adj: bool, default True
-            If True, a cluster correction G/(G-1) is performed, with G the number of clusters.
-        cluster_df: str, default "conventional"
+        adj : bool, default True
+            If True, applies a small sample correction of (N-1) / (N-k) where N
+            is the number of observations and k is the number of estimated
+            coefficients excluding any fixed effects projected out in either
+            fixest::feols() or lfe::felm().
+        fixef_k : str, default "none"
+            Equal to 'none': the fixed effects parameters are discarded when
+            calculating k in (N-1) / (N-k).
+        cluster_adj : bool, default True
+            If True, a cluster correction G/(G-1) is performed, with G the number
+            of clusters.
+        cluster_df : str, default "conventional"
             Controls how "G" is computed for multiway clustering if cluster_adj = True.
             Note that the covariance matrix in the multiway clustering case is of
             the form V = V_1 + V_2 - V_12. If "conventional", then each summand G_i
@@ -25,6 +29,7 @@ def ssc(adj=True, fixef_k="none", cluster_adj=True, cluster_df="min"):
 
     Returns
     -------
+    dict
         A dictionary with encoded info on how to form small sample corrections
     """
     if adj not in [True, False]:
@@ -63,7 +68,8 @@ def get_ssc(ssc_dict, N, k, G, vcov_sign, vcov_type, is_twoway=False):
     vcov_type : str
         The type of covariance matrix. Must be one of "iid", "hetero", or "CRV".
     is_twoway : bool, optional
-        Whether the covariance matrix is of the form V = V_1 + V_2 - V_12. Default is False.
+        Whether the covariance matrix is of the form V = V_1 + V_2 - V_12.
+            Default is False.
 
     Returns
     -------
@@ -73,7 +79,8 @@ def get_ssc(ssc_dict, N, k, G, vcov_sign, vcov_type, is_twoway=False):
     Raises
     ------
     ValueError
-        If vcov_type is not "iid", "hetero", or "CRV", or if cluster_df is neither "conventional" nor "min".
+        If vcov_type is not "iid", "hetero", or "CRV", or if cluster_df is neither
+        "conventional" nor "min".
     """
     adj = ssc_dict["adj"]
     fixef_k = ssc_dict["fixef_k"]  # noqa: F841 TODO: is this used?
@@ -266,7 +273,8 @@ def absolute_diff(x, y, tol=1e-03):
     Returns
     -------
     bool
-        True if the absolute difference is greater than the tolerance and there is a non-zero value in y, False otherwise.
+        True if the absolute difference is greater than the tolerance and there
+        is a non-zero value in y, False otherwise.
     """
     absolute_diff = (np.abs(x - y) > tol).any()
     if not any(y == 0):

--- a/pyfixest/utils.py
+++ b/pyfixest/utils.py
@@ -12,8 +12,8 @@ def ssc(adj=True, fixef_k="none", cluster_adj=True, cluster_df="min"):
         adj : bool, default True
             If True, applies a small sample correction of (N-1) / (N-k) where N
             is the number of observations and k is the number of estimated
-            coefficients excluding any fixed effects projected out in either
-            fixest::feols() or lfe::felm().
+            coefficients excluding any fixed effects projected out by either
+            `feols()` or `fepois()`.
         fixef_k : str, default "none"
             Equal to 'none': the fixed effects parameters are discarded when
             calculating k in (N-1) / (N-k).

--- a/pyfixest/visualize.py
+++ b/pyfixest/visualize.py
@@ -36,12 +36,16 @@ def iplot(
     coord_flip: Optional[bool] = True,
 ):
     """
-    Plot model coefficients for variables interacted via "i()" syntax, with confidence intervals.
+    Plot model coefficients.
+
+    Plot model coefficients for variables interacted via "i()" syntax, with
+    confidence intervals.
 
     Parameters
     ----------
     models : list or object
-        A list of fitted models of type [Feols(/reference/Feols.qmd) or `Fepois`, or just a single model.
+        A list of fitted models of type `Feols` or
+        `Fepois`, or just a single model.
     figsize : tuple
         The size of the figure.
     alpha : float
@@ -132,7 +136,7 @@ def coefplot(
     Parameters
     ----------
     models : list or object
-        A list of fitted models of type [Feols(/reference/Feols.qmd) or `Fepois`, or just a single model.
+        A list of fitted models of type `Feols` or `Fepois`, or just a single model.
     figsize : tuple
         The size of the figure.
     alpha : float

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ select = [
   "E", # pycodestyle errors
   "W", # pycodestyle warnings
   "I", # isort
-#  "D", # flake8-docstrings
+  "D", # flake8-docstrings
   "UP", # pyupgrade
   "SIM", # flake8-simplify
   "TRY", # tryceratops
@@ -84,11 +84,15 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*.py" = ["D100", "D103"]
 
+[tool.ruff.lint.pycodestyle]
+max-doc-length = 88
+
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"
 
 [tool.ruff.format]
 docstring-code-format = true
+docstring-code-line-length = 88
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -17,9 +17,7 @@ broom = importr("broom")
 
 
 def test_event_study():
-    """
-    Test the event_study() function.
-    """
+    """Test the event_study() function."""
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
 
     fit_did2s = event_study(
@@ -49,9 +47,7 @@ def test_event_study():
 
 
 def test_did2s():
-    """
-    Test the did2s() function.
-    """
+    """Test the did2s() function."""
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
     df_het["X"] = np.random.normal(size=len(df_het))
 
@@ -208,9 +204,7 @@ def test_errors():
 
 
 def test_lpdid():
-    """
-    test the lpdid estimator.
-    """
+    """Test the lpdid estimator."""
     # test vs stata
     df_het = pd.read_stata("pyfixest/did/data/lpdidtestdata1.dta")
     df_het = df_het.astype(np.float64)

--- a/tests/test_did.py
+++ b/tests/test_did.py
@@ -20,7 +20,6 @@ def test_event_study():
     """
     Test the event_study() function.
     """
-
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
 
     fit_did2s = event_study(
@@ -53,7 +52,6 @@ def test_did2s():
     """
     Test the did2s() function.
     """
-
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
     df_het["X"] = np.random.normal(size=len(df_het))
 
@@ -213,7 +211,6 @@ def test_lpdid():
     """
     test the lpdid estimator.
     """
-
     # test vs stata
     df_het = pd.read_stata("pyfixest/did/data/lpdidtestdata1.dta")
     df_het = df_het.astype(np.float64)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -50,7 +50,6 @@ def test_cluster_na():
     test if a nan value in a cluster variable raises
     an error
     """
-
     data = get_data()
     data = data.dropna()
     data["f3"] = data["f3"].astype("int64")
@@ -77,7 +76,6 @@ def test_depvar_numeric():
     """
     test if feols() throws an error when the dependent variable is not numeric
     """
-
     data = get_data()
     data["Y"] = data["Y"].astype("str")
     data["Y"] = pd.Categorical(data["Y"])
@@ -131,7 +129,6 @@ def test_poisson_devpar_count():
     """
     check that the dependent variable is a count variable
     """
-
     data = get_data()
     # under determined
     with pytest.raises(AssertionError):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -46,10 +46,7 @@ def test_i_ref():
 
 
 def test_cluster_na():
-    """
-    test if a nan value in a cluster variable raises
-    an error
-    """
+    """Test if a nan value in a cluster variable raises an error."""
     data = get_data()
     data = data.dropna()
     data["f3"] = data["f3"].astype("int64")
@@ -61,7 +58,11 @@ def test_cluster_na():
 
 def test_error_hc23_fe():
     """
-    test if HC2&HC3 inference with fixed effects regressions raises an error (currently not supported)
+    Test if HC2 & HC3 inference with fixed effects regressions raises an error.
+
+    Notes
+    -----
+    Currently not supported.
     """
     data = get_data().dropna()
 
@@ -73,9 +74,7 @@ def test_error_hc23_fe():
 
 
 def test_depvar_numeric():
-    """
-    test if feols() throws an error when the dependent variable is not numeric
-    """
+    """Test if feols() throws an error when the dependent variable is not numeric."""
     data = get_data()
     data["Y"] = data["Y"].astype("str")
     data["Y"] = pd.Categorical(data["Y"])
@@ -93,7 +92,7 @@ def test_iv_errors():
     # instrument specified as covariate
     with pytest.raises(InstrumentsAsCovarsError):
         feols(fml="Y ~ X1 | Z1  ~ X1 + X2", data=data)
-    # endogeneous variable specified as covariate
+    # endogenous variable specified as covariate
     with pytest.raises(EndogVarsAsCovarsError):
         feols(fml="Y ~ Z1 | Z1  ~ X1", data=data)
     # instrument specified as covariate
@@ -126,9 +125,7 @@ def test_iv_errors():
 
 @pytest.mark.skip("Not yet implemented.")
 def test_poisson_devpar_count():
-    """
-    check that the dependent variable is a count variable
-    """
+    """Check that the dependent variable is a count variable."""
     data = get_data()
     # under determined
     with pytest.raises(AssertionError):

--- a/tests/test_i.py
+++ b/tests/test_i.py
@@ -88,7 +88,7 @@ def test_i():
 def test_i_vs_fixest():
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
 
-    # ---------------------------------------------------------------------------------------#
+    # ------------------------------------------------------------------------ #
     # no fixed effects
 
     # no references
@@ -123,7 +123,7 @@ def test_i_vs_fixest():
         fit_py.coef().values, np.array(fit_r.rx2("coefficients"))
     )
 
-    # ---------------------------------------------------------------------------------------#
+    # ------------------------------------------------------------------------ #
     # with fixed effects
 
     # no references
@@ -163,7 +163,7 @@ def test_i_interacted_fixest():
     df_het = pd.read_csv("pyfixest/did/data/df_het.csv")
     df_het["X"] = np.random.normal(df_het.shape[0])
 
-    # ---------------------------------------------------------------------------------------#
+    # ------------------------------------------------------------------------ #
     # no fixed effects
 
     # no references

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -6,9 +6,7 @@ from pyfixest.estimation import fepois
 
 
 def test_separation():
-    """
-    Test separation detection.
-    """
+    """Test separation detection."""
     y = np.array([0, 0, 0, 1, 2, 3])
     df1 = np.array(["a", "a", "b", "b", "b", "c"])
     df2 = np.array(["c", "c", "d", "d", "d", "e"])

--- a/tests/test_poisson.py
+++ b/tests/test_poisson.py
@@ -9,7 +9,6 @@ def test_separation():
     """
     Test separation detection.
     """
-
     y = np.array([0, 0, 0, 1, 2, 3])
     df1 = np.array(["a", "a", "b", "b", "b", "c"])
     df2 = np.array(["c", "c", "d", "d", "d", "e"])

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -30,7 +30,6 @@ def test_internally(data):
     Test predict() method internally.
     Currently only for OLS.
     """
-
     # predict via feols, without fixed effect
     fit = feols(fml="Y~csw(X1, X2)", data=data, vcov="iid")
     mod = fit.fetch_model(0)
@@ -78,7 +77,6 @@ def test_vs_fixest(data, fml):
     """
     Test predict and resid methods against fixest.
     """
-
     feols_mod = feols(fml=fml, data=data, vcov="HC1")
     fepois_mod = fepois(fml=fml, data=data, vcov="HC1")
 
@@ -240,7 +238,6 @@ def test_categorical_covariate_predict():
     """
     Test if predict handles missing levels in covariate correctly.
     """
-
     rng = np.random.default_rng(12345)
     df = pd.DataFrame(
         {

--- a/tests/test_predict_resid_fixef.py
+++ b/tests/test_predict_resid_fixef.py
@@ -28,6 +28,9 @@ def data():
 def test_internally(data):
     """
     Test predict() method internally.
+
+    Notes
+    -----
     Currently only for OLS.
     """
     # predict via feols, without fixed effect
@@ -74,9 +77,7 @@ def test_internally(data):
     ],
 )
 def test_vs_fixest(data, fml):
-    """
-    Test predict and resid methods against fixest.
-    """
+    """Test predict and resid methods against fixest."""
     feols_mod = feols(fml=fml, data=data, vcov="HC1")
     fepois_mod = fepois(fml=fml, data=data, vcov="HC1")
 
@@ -143,7 +144,7 @@ def test_vs_fixest(data, fml):
         raise ValueError("Predictions for OLS are not of the same length.")
 
     # test predict for Poisson
-    # if not np.allclose(fepois_mod.predict(data = data2), stats.predict(r_fixest_pois, newdata = data2)):
+    # if not np.allclose(fepois_mod.predict(data = data2), stats.predict(r_fixest_pois, newdata = data2)):  # noqa: W505
     #    raise ValueError("Predictions for Poisson are not equal")
 
     # test resid for OLS
@@ -235,9 +236,7 @@ def test_new_fixef_level(data, fml):
 
 
 def test_categorical_covariate_predict():
-    """
-    Test if predict handles missing levels in covariate correctly.
-    """
+    """Test if predict handles missing levels in covariate correctly."""
     rng = np.random.default_rng(12345)
     df = pd.DataFrame(
         {

--- a/tests/test_ses.py
+++ b/tests/test_ses.py
@@ -59,7 +59,7 @@ def test_HC3_vs_CRV3(N, seed, beta_type, error_type):
     # adj: default adjustments are different for HC3 and CRV3
     adj_correction = np.sqrt((N - 1) / N)
 
-    # if not np.allclose(np.sort(res_hc3["Std. Error"]) * adj_correction , np.sort(res_crv3["Std. Error"])):
+    # if not np.allclose(np.sort(res_hc3["Std. Error"]) * adj_correction , np.sort(res_crv3["Std. Error"])):  # noqa: W505
     #    raise ValueError("HC3 and CRV3 ses are not the same.")
     if not np.allclose(res_hc3["t value"] / adj_correction, res_crv3["t value"]):
         raise ValueError("HC3 and CRV3 t values are not the same.")

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -5,7 +5,6 @@ from pyfixest.utils import get_data
 
 def test_summary():
     """Just run etable() and summary() on a few models."""
-
     df1 = get_data()
     df2 = get_data(model="Fepois")
 

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -55,17 +55,17 @@ rng = np.random.default_rng(8760985)
         ("Y ~ X1 + C(f1) + C(f2)"),
         ("Y ~ X1 + C(f1) | f2"),
         ("Y ~ X1 + C(f1) | f2 + f3"),
-        # ("Y ~ X1 + C(f1):C(fe2)"),            # currently does not work as C():C() translation not implemented
-        # ("Y ~ X1 + C(f1):C(fe2) | f3"),       # currently does not work as C():C() translation not implemented
+        # ("Y ~ X1 + C(f1):C(fe2)"),                  # currently does not work as C():C() translation not implemented # noqa: W505
+        # ("Y ~ X1 + C(f1):C(fe2) | f3"),             # currently does not work as C():C() translation not implemented # noqa: W505
         ("Y~X1|f2^f3"),
         ("Y~X1|f1 + f2^f3"),
         # ("Y~X1|f2^f3^f1"),
         ("Y ~ X1 + X2:f1"),
         ("Y ~ X1 + X2:f1 | f3"),
         ("Y ~ X1 + X2:f1 | f3 + f1"),
-        # ("log(Y) ~ X1:X2 | f3 + f1"),               # currently, causes big problems for Fepois (takes a long time)
-        # ("log(Y) ~ log(X1):X2 | f3 + f1"),          # currently, causes big problems for Fepois (takes a long time)
-        # ("Y ~  X2 + exp(X1) | f3 + f1"),            # currently, causes big problems for Fepois (takes a long time)
+        # ("log(Y) ~ X1:X2 | f3 + f1"),               # currently, causes big problems for Fepois (takes a long time) # noqa: W505
+        # ("log(Y) ~ log(X1):X2 | f3 + f1"),          # currently, causes big problems for Fepois (takes a long time) # noqa: W505
+        # ("Y ~  X2 + exp(X1) | f3 + f1"),            # currently, causes big problems for Fepois (takes a long time) # noqa: W505
         ("Y ~ X1 + i(f1,X2)"),  # temporarily non-supported feature
         ("Y ~ X1 + i(f2,X2)"),  # temporarily non-supported feature
         ("Y ~ X1 + i(f1,X2) | f2"),  # temporarily non-supported feature
@@ -76,16 +76,16 @@ rng = np.random.default_rng(8760985)
         # ("Y ~ i(f1,X2, ref='4.0') | f2 + f3"),     # currently does not work
         ("Y ~ X1 + C(f1)"),
         ("Y ~ X1 + C(f1) + C(f2)"),
-        # ("Y ~ C(f1):X2"),                          # currently does not work as C():X translation not implemented
+        # ("Y ~ C(f1):X2"),                          # currently does not work as C():X translation not implemented # noqa: W505
         # ("Y ~ C(f1):C(f2)"),                       # currently does not work
         ("Y ~ X1 + C(f1) | f2"),
         ("Y ~ X1 + I(X2 ** 2)"),
         ("Y ~ X1 + I(X1 ** 2) + I(X2**4)"),
         ("Y ~ X1*X2"),
         ("Y ~ X1*X2 | f1+f2"),
-        # ("Y ~ X1/X2"),                             # currently does not work as X1/X2 translation not implemented
-        # ("Y ~ X1/X2 | f1+f2"),                     # currently does not work as X1/X2 translation not implemented
-        # ("Y ~ X1 + poly(X2, 2) | f1"),             # bug in formulaic in case of NAs in X1, X2
+        # ("Y ~ X1/X2"),                             # currently does not work as X1/X2 translation not implemented # noqa: W505
+        # ("Y ~ X1/X2 | f1+f2"),                     # currently does not work as X1/X2 translation not implemented # noqa: W505
+        # ("Y ~ X1 + poly(X2, 2) | f1"),             # bug in formulaic in case of NAs in X1, X2 # noqa: W505
         # IV starts here
         ("Y ~ 1 | X1 ~ Z1"),
         "Y ~  X2 | X1 ~ Z1",
@@ -113,7 +113,7 @@ def test_single_fit(
     N, seed, beta_type, error_type, dropna, model, inference, weights, fml
 ):
     """
-    test pyfixest against fixest via rpy2 (OLS, IV, Poisson)
+    Test pyfixest against fixest via rpy2 (OLS, IV, Poisson).
 
         - for multiple models
         - and multiple inference types
@@ -255,7 +255,8 @@ def test_single_fit(
             r_nobs = stats.nobs(r_fixest)
 
     if run_test:
-        # get coefficients, standard errors, p-values, t-statistics, confidence intervals
+        # get coefficients, standard errors, p-values, t-statistics,
+        # confidence intervals
 
         mod = pyfixest
 
@@ -446,9 +447,7 @@ def test_single_fit(
     ],
 )
 def test_multi_fit(N, seed, beta_type, error_type, dropna, fml_multi):
-    """
-    test pyfixest against fixest_multi objects
-    """
+    """Test pyfixest against fixest_multi objects."""
     data = get_data(N=N, seed=seed, beta_type=beta_type, error_type=error_type)
     data[data == "nan"] = np.nan
 
@@ -561,9 +560,7 @@ def test_twoway_clustering():
 
 
 def test_wls_na():
-    """
-    Special tests for WLS and NA values
-    """
+    """Special tests for WLS and NA values."""
     data = get_data()
     data = data.dropna()
 
@@ -623,6 +620,8 @@ def test_wls_na():
 
 def _py_fml_to_r_fml(py_fml):
     """
+    Covernt pyfixest formula.
+
     pyfixest multiple estimation fml syntax to fixest multiple depvar
     syntax converter,
     i.e. 'Y1 + X2 ~ X' -> 'c(Y1, Y2) ~ X'
@@ -644,9 +643,7 @@ def _py_fml_to_r_fml(py_fml):
 
 
 def _c_to_as_factor(py_fml):
-    """
-    transform formulaic C-syntax for categorical variables into R's as.factor
-    """
+    """Transform formulaic C-syntax for categorical variables into R's as.factor."""
     # Define a regular expression pattern to match "C(variable)"
     pattern = r"C\((.*?)\)"
 
@@ -681,9 +678,7 @@ def get_data_r(fml, data):
 
 @pytest.mark.skip("Currently not supported.")
 def test_i_interaction():
-    """
-    Test that interaction syntax via the `i()` operator works as in fixest
-    """
+    """Test that interaction syntax via the `i()` operator works as in fixest."""
     data = get_data(N=1000, seed=17021, beta_type="1", error_type="1").dropna()
 
     fit1 = feols("Y ~ i(f1, X2)", data=data)

--- a/tests/test_vs_fixest.py
+++ b/tests/test_vs_fixest.py
@@ -120,7 +120,6 @@ def test_single_fit(
         - ... compare regression coefficients and standard errors
         - tba: t-statistics, covariance matrices, other metrics
     """
-
     inference_inflation_factor = 1.0
 
     if model == "Feols":
@@ -450,7 +449,6 @@ def test_multi_fit(N, seed, beta_type, error_type, dropna, fml_multi):
     """
     test pyfixest against fixest_multi objects
     """
-
     data = get_data(N=N, seed=seed, beta_type=beta_type, error_type=error_type)
     data[data == "nan"] = np.nan
 
@@ -566,7 +564,6 @@ def test_wls_na():
     """
     Special tests for WLS and NA values
     """
-
     data = get_data()
     data = data.dropna()
 
@@ -630,7 +627,6 @@ def _py_fml_to_r_fml(py_fml):
     syntax converter,
     i.e. 'Y1 + X2 ~ X' -> 'c(Y1, Y2) ~ X'
     """
-
     py_fml = py_fml.replace(" ", "").replace("C(", "as.factor(")
 
     fml2 = py_fml.split("|")
@@ -688,7 +684,6 @@ def test_i_interaction():
     """
     Test that interaction syntax via the `i()` operator works as in fixest
     """
-
     data = get_data(N=1000, seed=17021, beta_type="1", error_type="1").dropna()
 
     fit1 = feols("Y ~ i(f1, X2)", data=data)


### PR DESCRIPTION
Enabling the docstyle linting and formatting with Ruff rule "D".

Changes:
- Uncommented the "D" linting rule
- Set docstyle line width to 88
- standardized docstrings to the numpy docstring format style: https://numpydoc.readthedocs.io/en/latest/format.html#sections
- minor spelling fixes

I've tried to standardize the format and conventions as much as possible.

I ran quartodoc to confirm that docs build. I also ran tests to confirm that they pass.