### PR TITLE
dev: Support custom statistics in `etable()` output (#306)

### DIFF
--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -153,10 +153,9 @@ def etable(
             elif element == "p":
                 model[coef_fmt_title] += model["Pr(>|t|)"].astype(str)
             elif element in custom_statistics:
-                if len(custom_statistics[key][i]) != len(model["Estimate"]):
-                    raise ValueError(
-                        f"Custom_statistics {key} has unequal length to the number of coefficients in model {i}"
-                    )
+                assert len(custom_statistics[key][i]) != len(
+                    model["Estimate"]
+                ), f"Custom_statistics {key} has unequal length to the number of coefficients in model {i}"
                 model[coef_fmt_title] += pd.Series(
                     np.round(custom_statistics[element][i], digits)
                 ).astype(str)

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -16,7 +16,7 @@ def etable(
     type: Optional[str] = "md",
     signif_code: Optional[list] = [0.001, 0.01, 0.05],
     coef_fmt: Optional[str] = "b (se)",
-    custom_statistics: Optional[dict] = None,
+    custom_statistics: Optional[dict] = dict(),
 ) -> Union[pd.DataFrame, str]:
     """
     Create an esttab-like table from a list of models.
@@ -39,8 +39,7 @@ def etable(
         Spaces ` `, parentheses `()`, brackets `[]`, newlines `\n` are supported.
         Newline is not support for LaTeX output.
     custom_statistics: dict, optional
-        A dictionary of custom statistics. Key should be lowercased (e.g., simul_intv).
-        "b", "se", "t", or "p" are reserved.
+        A dictionary of custom statistics. "b", "se", "t", or "p" are reserved.
 
     Returns
     -------

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -153,9 +153,9 @@ def etable(
             elif element == "p":
                 model[coef_fmt_title] += model["Pr(>|t|)"].astype(str)
             elif element in custom_statistics:
-                assert len(custom_statistics[key][i]) == len(
+                assert len(custom_statistics[element][i]) == len(
                     model["Estimate"]
-                ), f"Custom_statistics {key} has unequal length to the number of coefficients in model {i}"
+                ), f"Custom_statistics {element} has unequal length to the number of coefficients in model {i}"
                 model[coef_fmt_title] += pd.Series(
                     np.round(custom_statistics[element][i], digits)
                 ).astype(str)

--- a/pyfixest/summarize.py
+++ b/pyfixest/summarize.py
@@ -153,7 +153,7 @@ def etable(
             elif element == "p":
                 model[coef_fmt_title] += model["Pr(>|t|)"].astype(str)
             elif element in custom_statistics:
-                assert len(custom_statistics[key][i]) != len(
+                assert len(custom_statistics[key][i]) == len(
                     model["Estimate"]
                 ), f"Custom_statistics {key} has unequal length to the number of coefficients in model {i}"
                 model[coef_fmt_title] += pd.Series(

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -225,3 +225,43 @@ def test_errors_etable():
 
     with pytest.raises(AssertionError):
         etable([fit1, fit2], signif_code=[0.1, 0.5, 1.5])
+
+    with pytest.raises(ValueError):
+        etable([fit1, fit2], coef_fmt="b (se) \n t [p]", type="tex")
+
+    with pytest.raises(ValueError):
+        etable(
+            models=[fit1, fit2],
+            custom_statistics={
+                "conf_int_lb": [
+                    fit2._conf_int[0]
+                ],  # length of customized statistics not equal to the number of models
+                "conf_int_ub": [fit2._conf_int[1]],
+            },
+            coef_fmt="b [conf_int_lb, conf_int_ub]",
+        )
+
+    with pytest.raises(ValueError):
+        etable(
+            models=[fit1, fit2],
+            custom_statistics={
+                "conf_int_lb": [
+                    fit2._conf_int[0],
+                    fit2._conf_int[0],
+                ],  # length of customized statistics not equal to length of model
+                "conf_int_ub": [fit1._conf_int[1], fit2._conf_int[1]],
+            },
+            coef_fmt="b [conf_int_lb, conf_int_ub]",
+        )
+
+    with pytest.raises(ValueError):
+        etable(
+            models=[fit1, fit2],
+            custom_statistics={
+                "b": [
+                    fit2._conf_int[0],
+                    fit2._conf_int[0],
+                ],  # preserved keyword cannot be used as a custom statistic
+            },
+            coef_fmt="b [se]",
+        )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -229,7 +229,7 @@ def test_errors_etable():
     with pytest.raises(ValueError):
         etable([fit1, fit2], coef_fmt="b (se) \n t [p]", type="tex")
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         etable(
             models=[fit1, fit2],
             custom_statistics={
@@ -241,7 +241,7 @@ def test_errors_etable():
             coef_fmt="b [conf_int_lb, conf_int_ub]",
         )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(AssertionError):
         etable(
             models=[fit1, fit2],
             custom_statistics={

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -246,7 +246,7 @@ def test_errors_etable():
             models=[fit1, fit2],
             custom_statistics={
                 "conf_int_lb": [
-                    fit2._conf_int[0],
+                    [0.1, 0.1, 0.1],
                     fit2._conf_int[0],
                 ],  # length of customized statistics not equal to length of model
                 "conf_int_ub": [fit1._conf_int[1], fit2._conf_int[1]],

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -32,5 +32,13 @@ def test_summary():
     etable([fit1, fit2], signif_code=[0.01, 0.05, 0.1])
     etable([fit1, fit2], signif_code=None)
 
-    etable([fit1, fit2], coef_fmt="t (p)")
-    etable([fit1, fit2], coef_fmt="t (p) \n t (t)")
+    etable([fit1, fit2], coef_fmt="b (se) \n t [p]")
+
+    etable(
+        models=[fit1, fit2],
+        custom_statistics={
+            "conf_int_lb": [fit1._conf_int[0], fit2._conf_int[0]],
+            "conf_int_ub": [fit1._conf_int[1], fit2._conf_int[1]],
+        },
+        coef_fmt="b [conf_int_lb, conf_int_ub]",
+    )


### PR DESCRIPTION
Hi @s3alfisc, I developed the custom statistics support for `etable()` as mentioned in #306.

`etable()` now has a new parameter `custom_statistics`, which accept dictionary input. A legal input should be:

1. Each key represents a new statistic and can be referenced in the `coef_fmt` parameter.
2. Each element should be a list with the same length as the `models` parameter.
3. Each element of the list should be an iterable object with the same length as the corresponding `model` in `models`.

I add a test to cover this new feature

```python
etable(
    models=[fit1, fit2],
    custom_statistics={
        "conf_int_lb": [fit1._conf_int[0], fit2._conf_int[0]],
        "conf_int_ub": [fit1._conf_int[1], fit2._conf_int[1]],
    },
    coef_fmt="b [conf_int_lb, conf_int_ub]",
)
```

And the output is

```
                                    est1                    est2
------------  --------------------------  ----------------------
depvar                                 Y                       Y
----------------------------------------------------------------
X1             -0.95*** [-1.086, -0.813]   0.003 [-0.062, 0.068]
X2            -0.174*** [-0.212, -0.137]  -0.014 [-0.036, 0.007]
f2                                         0.003 [-0.005, 0.011]
----------------------------------------------------------------
f1                                     x                       x
----------------------------------------------------------------
R2                                 0.489                       -
S.E. type                         by: f1               by: f1+f2
Observations                         997                     997
----------------------------------------------------------------
Significance levels: * p < 0.05, ** p < 0.01, *** p < 0.001
Format of coefficient cell:
Coefficient [conf_int_lb, conf_int_ub]
```