### PR TITLE
dev: add exact_match to _select_order_coefs and etable

### DIFF
--- a/pyfixest/dev_utils.py
+++ b/pyfixest/dev_utils.py
@@ -1,4 +1,5 @@
-from typing import Union
+import re
+from typing import Optional, Union
 
 import pandas as pd
 
@@ -23,3 +24,77 @@ def _polars_to_pandas(data: DataFrameType) -> pd.DataFrame:  # type: ignore
             )
 
     return data
+
+
+def _select_order_coefs(
+    coefs: list,
+    keep: Optional[Union[list, str]] = [],
+    drop: Optional[Union[list, str]] = [],
+    exact_match: Optional[bool] = False,
+):
+    r"""
+    Select and order the coefficients based on the pattern.
+
+    Parameters
+    ----------
+    coefs: list
+        Coefficient names to be selected and ordered.
+    keep: str or list of str, optional
+        The pattern for retaining coefficient names. You can pass a string (one
+        pattern) or a list (multiple patterns). Default is keeping all coefficients.
+        You should use regular expressions to select coefficients.
+            "age",            # would keep all coefficients containing age
+            r"^tr",           # would keep all coefficients starting with tr
+            r"\\d$",          # would keep all coefficients ending with number
+        Output will be in the order of the patterns.
+    drop: str or list of str, optional
+        The pattern for excluding coefficient names. You can pass a string (one
+        pattern) or a list (multiple patterns). Syntax is the same as for `keep`.
+        Default is keeping all coefficients. Parameter `keep` and `drop` can be
+        used simultaneously.
+    exact_match: bool, optional
+        Whether to use exact match for `keep` and `drop`. Default is False.
+        If True, the pattern will be matched exactly to the coefficient name
+        instead of using regular expressions.
+
+    Returns
+    -------
+    res: list
+        The filtered and ordered coefficient names.
+    """
+    if isinstance(keep, str):
+        keep = [keep]
+    if isinstance(drop, str):
+        drop = [drop]
+
+    coefs = list(coefs)
+    res = [] if keep else coefs[:]  # Store matched coefs
+    for pattern in keep:
+        _coefs = []  # Store remaining coefs
+        for coef in coefs:
+            if (
+                exact_match
+                and pattern == coef
+                or exact_match is False
+                and re.findall(pattern, coef)
+            ):
+                res.append(coef)
+            else:
+                _coefs.append(coef)
+        coefs = _coefs
+
+    for pattern in drop:
+        _coefs = []
+        for coef in res:  # Remove previously matched coefs that match the drop pattern
+            if (
+                exact_match
+                and pattern == coef
+                or exact_match is False
+                and re.findall(pattern, coef)
+            ):
+                continue
+            else:
+                _coefs.append(coef)
+        res = _coefs
+
+    return res

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from pyfixest.estimation import feols, fepois
-from pyfixest.summarize import etable, summary
+from pyfixest.summarize import _select_order_coefs, etable, summary
 from pyfixest.utils import get_data
 
 
@@ -80,3 +80,13 @@ def test_summary():
     etable([fit1, fit2, fit3], coef_fmt="b (se)\nt [p]", keep=[r"\d"], drop=["f"])
     etable([fit1, fit2, fit3], coef_fmt="b (se)\nt [p]", keep="X")
     etable([fit1, fit2, fit3], coef_fmt="b (se)\nt [p]", drop=r"\d$")
+
+    cols = ["x1", "x2", "x11", "x21"]
+    assert _select_order_coefs(cols, keep=["x1"]) == ["x1", "x11"]
+    assert _select_order_coefs(cols, drop=["x1"]) == ["x2", "x21"]
+    assert _select_order_coefs(cols, keep=["x1"], exact_match=True) == ["x1"]
+    assert _select_order_coefs(cols, drop=["x1"], exact_match=True) == [
+        "x2",
+        "x11",
+        "x21",
+    ]


### PR DESCRIPTION
Echo issues #323 and #286, I add `exact_match` parameter to `_select_order_coefs()` function and move this function to `dev_utils.py` now. I also add some tests in `test_summary()` to verify `_select_order_coefs()` gives desirable results.

I haven't implemented them into `confint` and `coefplot` as mentioned in #323 yet.