### PR TITLE
fix: number of observations format

### DIFF
--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -115,11 +115,12 @@ def etable(
     for i, model in enumerate(models):
         dep_var_list.append(model._depvar)
         n_coefs.append(len(model._coefnames))
-        nobs_list.append(
-            _number_formatter(
-                model._N, integer=True, scientific_notation=False, **kwargs
-            )
-        )
+        
+        _nobs_kwargs = kwargs.copy()
+        _nobs_kwargs["integer"] = True
+        _nobs_kwargs["scientific_notation"] = False
+        nobs_list.append(_number_formatter(model._N, **_nobs_kwargs))
+        
         if model._method == "feols" and not model._is_iv and not model._has_weights:
             r2_list.append(_number_formatter(model._r2, **kwargs))
         else:

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -115,7 +115,11 @@ def etable(
     for i, model in enumerate(models):
         dep_var_list.append(model._depvar)
         n_coefs.append(len(model._coefnames))
-        nobs_list.append(_number_formatter(model._N, integer=True, scientific_notation=False, **kwargs))
+        nobs_list.append(
+            _number_formatter(
+                model._N, integer=True, scientific_notation=False, **kwargs
+            )
+        )
         if model._method == "feols" and not model._is_iv and not model._has_weights:
             r2_list.append(_number_formatter(model._r2, **kwargs))
         else:

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -115,7 +115,7 @@ def etable(
     for i, model in enumerate(models):
         dep_var_list.append(model._depvar)
         n_coefs.append(len(model._coefnames))
-        nobs_list.append(_number_formatter(model._N, integer=True, **kwargs))
+        nobs_list.append(_number_formatter(model._N, integer=True, scientific_notation=False, **kwargs))
         if model._method == "feols" and not model._is_iv and not model._has_weights:
             r2_list.append(_number_formatter(model._r2, **kwargs))
         else:


### PR DESCRIPTION
Hi Alex,

I am fixing a stupid thing I overlooked in formatting the table. Previously I mistakenly make the number of observations displayed in scientific notation if the number is large.

![image](https://github.com/s3alfisc/pyfixest/assets/30380959/ebd81954-30b3-4c84-80fb-ed6157dc134b)

After the fix, it will be:

![image](https://github.com/s3alfisc/pyfixest/assets/30380959/4c84ab75-0567-49b4-a748-e8990d50ab6f)

