### PR TITLE
Formula parser cleanup2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -127,18 +127,6 @@ doc = ["doc8", "sphinx (>=7.0.0)", "sphinx-autobuild", "sphinx-autodoc-typehints
 test = ["dateparser (>=1.0.0,<2.0.0)", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytz (==2021.1)", "simplejson (>=3.0.0,<4.0.0)"]
 
 [[package]]
-name = "astor"
-version = "0.8.1"
-description = "Read/rewrite/write Python ASTs"
-category = "main"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-files = [
-    {file = "astor-0.8.1-py2.py3-none-any.whl", hash = "sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5"},
-    {file = "astor-0.8.1.tar.gz", hash = "sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e"},
-]
-
-[[package]]
 name = "asttokens"
 version = "2.4.1"
 description = "Annotate AST trees with source code positions"
@@ -1092,14 +1080,14 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "7.0.2"
+version = "7.1.0"
 description = "Read metadata from Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.0.2-py3-none-any.whl", hash = "sha256:f4bc4c0c070c490abf4ce96d715f68e95923320370efb66143df00199bb6c100"},
-    {file = "importlib_metadata-7.0.2.tar.gz", hash = "sha256:198f568f3230878cb1b44fbd7975f87906c22336dba2e4a7f05278c281fbd792"},
+    {file = "importlib_metadata-7.1.0-py3-none-any.whl", hash = "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570"},
+    {file = "importlib_metadata-7.1.0.tar.gz", hash = "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"},
 ]
 
 [package.dependencies]
@@ -1108,18 +1096,18 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-perf (>=0.9.2)", "pytest-ruff (>=0.2.1)"]
 
 [[package]]
 name = "importlib-resources"
-version = "6.3.2"
+version = "6.4.0"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_resources-6.3.2-py3-none-any.whl", hash = "sha256:f41f4098b16cd140a97d256137cfd943d958219007990b2afb00439fc623f580"},
-    {file = "importlib_resources-6.3.2.tar.gz", hash = "sha256:963eb79649252b0160c1afcfe5a1d3fe3ad66edd0a8b114beacffb70c0674223"},
+    {file = "importlib_resources-6.4.0-py3-none-any.whl", hash = "sha256:50d10f043df931902d4194ea07ec57960f66a80449ff867bfe782b4c486ba78c"},
+    {file = "importlib_resources-6.4.0.tar.gz", hash = "sha256:cdb2b453b8046ca4e3798eb1d84f3cce1446a0e8e7b5ef4efb600f19fc398145"},
 ]
 
 [package.dependencies]
@@ -1127,7 +1115,7 @@ zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["jaraco.collections", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
+testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)", "zipp (>=3.17)"]
 
 [[package]]
 name = "iniconfig"
@@ -2009,14 +1997,14 @@ test = ["flaky", "ipykernel (>=6.19.3)", "ipython", "ipywidgets", "nbconvert (>=
 
 [[package]]
 name = "nbconvert"
-version = "7.16.2"
+version = "7.16.3"
 description = "Converting Jupyter Notebooks (.ipynb files) to other formats.  Output formats include asciidoc, html, latex, markdown, pdf, py, rst, script.  nbconvert can be used both as a Python library (`import nbconvert`) or as a command line tool (invoked as `jupyter nbconvert ...`)."
 category = "dev"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "nbconvert-7.16.2-py3-none-any.whl", hash = "sha256:0c01c23981a8de0220255706822c40b751438e32467d6a686e26be08ba784382"},
-    {file = "nbconvert-7.16.2.tar.gz", hash = "sha256:8310edd41e1c43947e4ecf16614c61469ebc024898eb808cce0999860fc9fb16"},
+    {file = "nbconvert-7.16.3-py3-none-any.whl", hash = "sha256:ddeff14beeeedf3dd0bc506623e41e4507e551736de59df69a91f86700292b3b"},
+    {file = "nbconvert-7.16.3.tar.gz", hash = "sha256:a6733b78ce3d47c3f85e504998495b07e6ea9cf9bf6ec1c98dda63ec6ad19142"},
 ]
 
 [package.dependencies]
@@ -2043,7 +2031,7 @@ docs = ["ipykernel", "ipython", "myst-parser", "nbsphinx (>=0.2.12)", "pydata-sp
 qtpdf = ["nbconvert[qtpng]"]
 qtpng = ["pyqtwebengine (>=5.15)"]
 serve = ["tornado (>=6.1)"]
-test = ["flaky", "ipykernel", "ipywidgets (>=7.5)", "pytest"]
+test = ["flaky", "ipykernel", "ipywidgets (>=7.5)", "pytest (>=7)"]
 webpdf = ["playwright"]
 
 [[package]]

--- a/pyfixest/errors/__init__.py
+++ b/pyfixest/errors/__init__.py
@@ -57,8 +57,10 @@ class MatrixNotFullRankError(Exception):  # noqa: D101
 class EmptyDesignMatrixError(Exception):  # noqa: D101
     pass
 
-class FeatureDeprecationError(Exception): # noqa: D101
+
+class FeatureDeprecationError(Exception):  # noqa: D101
     pass
+
 
 __all__ = [
     "FixedEffectInteractionError",

--- a/pyfixest/errors/__init__.py
+++ b/pyfixest/errors/__init__.py
@@ -57,6 +57,8 @@ class MatrixNotFullRankError(Exception):  # noqa: D101
 class EmptyDesignMatrixError(Exception):  # noqa: D101
     pass
 
+class FeatureDeprecationError(Exception): # noqa: D101
+    pass
 
 __all__ = [
     "FixedEffectInteractionError",
@@ -74,4 +76,5 @@ __all__ = [
     "NonConvergenceError",
     "MatrixNotFullRankError",
     "EmptyDesignMatrixError",
+    "FeatureDeprecationError",
 ]

--- a/pyfixest/estimation/FixestMulti_.py
+++ b/pyfixest/estimation/FixestMulti_.py
@@ -620,46 +620,6 @@ class FixestMulti:
         return model
 
 
-def get_fml(
-    depvar: str, covar: str, fval: str, endogvars: str = None, instruments: str = None
-) -> str:
-    """
-    Stitches together the formula string for the regression.
-
-    Parameters
-    ----------
-    depvar : str
-        The dependent variable.
-    covar : str
-        The covariates. E.g. "X1+X2+X3"
-    fval : str
-        The fixed effects. E.g. "X1+X2". "0" if no fixed effects.
-    endogvars : str, optional
-        The endogenous variables.
-    instruments : str, optional
-        The instruments. E.g. "Z1+Z2+Z3"
-
-    Returns
-    -------
-    str
-        The formula string for the regression.
-    """
-    fml = f"{depvar} ~ {covar}"
-    fml_iv = f"| {endogvars} ~ {instruments}" if endogvars is not None else None
-
-    fml_fval = f"| {fval}" if fval != "0" else None
-
-    if fml_fval is not None:
-        fml += fml_fval
-
-    if fml_iv is not None:
-        fml += fml_iv
-
-    fml = fml.replace(" ", "")
-
-    return fml
-
-
 def _get_vcov_type(vcov, fval):
     """
     Pass the specified vcov type.

--- a/pyfixest/estimation/FormulaParser.py
+++ b/pyfixest/estimation/FormulaParser.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from pyfixest.errors import (
     DuplicateKeyError,
+    EndogVarsAsCovarsError,
     InstrumentsAsCovarsError,
     UnderDeterminedIVError,
     UnsupportedMultipleEstimationSyntax,
@@ -492,7 +493,7 @@ def _deparse_fml(fml):
             fevars = "0"
             endogvars, instruments = fml_split[1].split("~")
             # add endogenous variable to "covars" - yes, bad naming
-
+            _check_endogvars_as_covars(endogvars, covars)
             covars = endogvars if covars == "1" else f"{endogvars}+{covars}"
         else:
             fevars = fml_split[1]
@@ -501,6 +502,7 @@ def _deparse_fml(fml):
     elif len(fml_split) == 3:
         fevars = fml_split[1]
         endogvars, instruments = fml_split[2].split("~")
+        _check_endogvars_as_covars(endogvars, covars)
 
         # add endogenous variable to "covars" - yes, bad naming
         covars = endogvars if covars == "1" else f"{endogvars}+{covars}"
@@ -519,6 +521,42 @@ def _deparse_fml(fml):
 
     return depvars, covars, fevars, endogvars, instruments
 
+
+def _check_endogvars_as_covars(endogvars: str, covars: str):
+
+        """
+        Check if one or more endogenous variables are included in the covariates.
+
+        Parameters
+        ----------
+        endogvars : str
+            A string representing the endogenous variables in the model, separated by "+".
+        covars : str
+            A string representing the covariates in the model, separated by "+".
+
+        Raises
+        ------
+        EndogVarsAsCovarsError
+            If any of the specified endogenous variables are also listed as covariates.
+
+        Returns
+        -------
+        None
+        """
+
+        endogvars_as_covars = [
+            element
+            for element in endogvars.split("+")
+            if element in covars.split("+")
+        ]
+
+        if endogvars_as_covars:
+            raise EndogVarsAsCovarsError(
+                f"""
+                The endogeneous variable(s) {",".join(endogvars_as_covars)} are specified as
+                covariates in the first part of the three-part formula. This is not allowed.
+                """
+            )
 
 def _input_formula_to_dict(x):
     """

--- a/pyfixest/estimation/FormulaParser.py
+++ b/pyfixest/estimation/FormulaParser.py
@@ -523,40 +523,38 @@ def _deparse_fml(fml):
 
 
 def _check_endogvars_as_covars(endogvars: str, covars: str):
+    """
+    Check if one or more endogenous variables are included in the covariates.
 
-        """
-        Check if one or more endogenous variables are included in the covariates.
+    Parameters
+    ----------
+    endogvars : str
+        A string representing the endogenous variables in the model,
+        separated by "+".
+    covars : str
+        A string representing the covariates in the model, separated by "+".
 
-        Parameters
-        ----------
-        endogvars : str
-            A string representing the endogenous variables in the model, separated by "+".
-        covars : str
-            A string representing the covariates in the model, separated by "+".
+    Raises
+    ------
+    EndogVarsAsCovarsError
+        If any of the specified endogenous variables are also listed as covariates.
 
-        Raises
-        ------
-        EndogVarsAsCovarsError
-            If any of the specified endogenous variables are also listed as covariates.
+    Returns
+    -------
+    None
+    """
+    endogvars_as_covars = [
+        element for element in endogvars.split("+") if element in covars.split("+")
+    ]
 
-        Returns
-        -------
-        None
-        """
-
-        endogvars_as_covars = [
-            element
-            for element in endogvars.split("+")
-            if element in covars.split("+")
-        ]
-
-        if endogvars_as_covars:
-            raise EndogVarsAsCovarsError(
-                f"""
+    if endogvars_as_covars:
+        raise EndogVarsAsCovarsError(
+            f"""
                 The endogeneous variable(s) {",".join(endogvars_as_covars)} are specified as
                 covariates in the first part of the three-part formula. This is not allowed.
                 """
-            )
+        )
+
 
 def _input_formula_to_dict(x):
     """

--- a/pyfixest/estimation/estimation.py
+++ b/pyfixest/estimation/estimation.py
@@ -7,6 +7,7 @@ from pyfixest.estimation.fepois_ import Fepois
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.utils.dev_utils import DataFrameType
 from pyfixest.utils.utils import ssc
+from pyfixest.errors import FeatureDeprecationError
 
 
 def feols(
@@ -18,6 +19,7 @@ def feols(
     fixef_rm: str = "none",
     collin_tol: float = 1e-10,
     drop_intercept: bool = False,
+    i_ref1 = None
 ) -> Union[Feols, FixestMulti]:
     """
     Estimate a linear regression models with fixed effects using fixest formula syntax.
@@ -55,6 +57,11 @@ def feols(
 
     drop_intercept : bool, optional
         Whether to drop the intercept from the model, by default False.
+
+    i_ref1: None
+        Deprecated with pyfixest version 0.18.0. Please use i-syntax instead, i.e.
+        feols('Y~ i(f1, ref=1)', data = data) instead of the former
+        feols('Y~ i(f1)', data = data, i_ref=1).
 
     Returns
     -------
@@ -230,6 +237,17 @@ def feols(
     ```
 
     """
+
+    if i_ref1 is not None:
+
+        raise FeatureDeprecationError(
+            """
+            The 'i_ref1' function argument is deprecated with pyfixest version 0.18.0.
+            Please use i-syntax instead, i.e. feols('Y~ i(f1, ref=1)', data = data)
+            instead of the former feols('Y~ i(f1)', data = data, i_ref=1).
+            """
+        )
+
     _estimation_input_checks(fml, data, vcov, weights, ssc, fixef_rm, collin_tol)
 
     fixest = FixestMulti(data=data)
@@ -256,6 +274,7 @@ def fepois(
     iwls_maxiter: int = 25,
     collin_tol: float = 1e-10,
     drop_intercept: bool = False,
+    i_ref1 = None
 ) -> Union[Fepois, FixestMulti]:
     """
     Estimate Poisson regression model with fixed effects using the `ppmlhdfe` algorithm.
@@ -323,6 +342,16 @@ def fepois(
     For more examples, please take a look at the documentation of the `feols()`
     function.
     """
+
+    if i_ref1 is not None:
+
+        raise FeatureDeprecationError(
+            """
+            The 'i_ref1' function argument is deprecated with pyfixest version 0.18.0.
+            Please use i-syntax instead, i.e. fepois('Y~ i(f1, ref=1)', data = data)
+            instead of the former fepois('Y~ i(f1)', data = data, i_ref=1).
+            """
+        )
     weights = None
 
     _estimation_input_checks(fml, data, vcov, weights, ssc, fixef_rm, collin_tol)

--- a/pyfixest/estimation/estimation.py
+++ b/pyfixest/estimation/estimation.py
@@ -2,12 +2,12 @@ from typing import Optional, Union
 
 import pandas as pd
 
+from pyfixest.errors import FeatureDeprecationError
 from pyfixest.estimation.feols_ import Feols
 from pyfixest.estimation.fepois_ import Fepois
 from pyfixest.estimation.FixestMulti_ import FixestMulti
 from pyfixest.utils.dev_utils import DataFrameType
 from pyfixest.utils.utils import ssc
-from pyfixest.errors import FeatureDeprecationError
 
 
 def feols(
@@ -19,7 +19,7 @@ def feols(
     fixef_rm: str = "none",
     collin_tol: float = 1e-10,
     drop_intercept: bool = False,
-    i_ref1 = None
+    i_ref1=None,
 ) -> Union[Feols, FixestMulti]:
     """
     Estimate a linear regression models with fixed effects using fixest formula syntax.
@@ -237,7 +237,6 @@ def feols(
     ```
 
     """
-
     if i_ref1 is not None:
 
         raise FeatureDeprecationError(
@@ -274,7 +273,7 @@ def fepois(
     iwls_maxiter: int = 25,
     collin_tol: float = 1e-10,
     drop_intercept: bool = False,
-    i_ref1 = None
+    i_ref1=None,
 ) -> Union[Fepois, FixestMulti]:
     """
     Estimate Poisson regression model with fixed effects using the `ppmlhdfe` algorithm.
@@ -342,7 +341,6 @@ def fepois(
     For more examples, please take a look at the documentation of the `feols()`
     function.
     """
-
     if i_ref1 is not None:
 
         raise FeatureDeprecationError(

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1673,13 +1673,14 @@ def _deparse_vcov_input(vcov, has_fixef, is_iv):
 
     # loop over clustervar to change "^" to "_"
     if clustervar:
-        clustervar = [x.replace("^", "_") for x in clustervar]
-        warnings.warn(
-            f"""
-            The '^' character in the cluster variable name is replaced by '_'.
-            In consequence, the clustering variable(s) is (are) named {clustervar}.
-            """
-        )
+        if "^" in clustervar:
+            clustervar = [x.replace("^", "_") for x in clustervar]
+            warnings.warn(
+                f"""
+                The '^' character in the cluster variable name is replaced by '_'.
+                In consequence, the clustering variable(s) is (are) named {clustervar}.
+                """
+            )
 
     return vcov_type, vcov_type_detail, is_clustered, clustervar
 

--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1672,15 +1672,14 @@ def _deparse_vcov_input(vcov, has_fixef, is_iv):
     clustervar = deparse_vcov if is_clustered else None
 
     # loop over clustervar to change "^" to "_"
-    if clustervar:
-        if "^" in clustervar:
-            clustervar = [x.replace("^", "_") for x in clustervar]
-            warnings.warn(
-                f"""
-                The '^' character in the cluster variable name is replaced by '_'.
-                In consequence, the clustering variable(s) is (are) named {clustervar}.
-                """
-            )
+    if clustervar and "^" in clustervar:
+        clustervar = [x.replace("^", "_") for x in clustervar]
+        warnings.warn(
+            f"""
+            The '^' character in the cluster variable name is replaced by '_'.
+            In consequence, the clustering variable(s) is (are) named {clustervar}.
+            """
+        )
 
     return vcov_type, vcov_type_detail, is_clustered, clustervar
 

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -115,12 +115,12 @@ def etable(
     for i, model in enumerate(models):
         dep_var_list.append(model._depvar)
         n_coefs.append(len(model._coefnames))
-        
+
         _nobs_kwargs = kwargs.copy()
         _nobs_kwargs["integer"] = True
         _nobs_kwargs["scientific_notation"] = False
         nobs_list.append(_number_formatter(model._N, **_nobs_kwargs))
-        
+
         if model._method == "feols" and not model._is_iv and not model._has_weights:
             r2_list.append(_number_formatter(model._r2, **kwargs))
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyfixest"
-version = "0.17.4"
+version = "0.18.0-beta.1"
 
 description = "Fast high dimensional fixed effect estimation following syntax of the fixest R package. Supports OLS, IV and Poisson regression and a range of inference procedures. Additionally, experimentally supports (some of) the regression based new Difference-in-Differences Estimators (Did2s)."
 authors = ["Alexander Fischer <alexander-fischer1801@t-online.de>", "Styfen Schär"]

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,13 +4,13 @@ import pytest
 
 from pyfixest.errors import (
     DuplicateKeyError,
-    InstrumentsAsCovarsError,
     EndogVarsAsCovarsError,
+    FeatureDeprecationError,
+    InstrumentsAsCovarsError,
     MultiEstNotSupportedError,
     NanInClusterVarError,
     UnderDeterminedIVError,
     VcovTypeNotSupportedError,
-    FeatureDeprecationError,
 )
 from pyfixest.estimation.estimation import feols, fepois
 from pyfixest.estimation.FormulaParser import FixestFormulaParser
@@ -87,7 +87,7 @@ def test_iv_errors():
         feols(fml="Y ~ X1 | Z1  ~ X1 + X2", data=data)
     # endogenous variable specified as covariate
     with pytest.raises(EndogVarsAsCovarsError):
-       feols(fml="Y ~ Z1 | Z1  ~ X1", data=data)
+        feols(fml="Y ~ Z1 | Z1  ~ X1", data=data)
 
     # instrument specified as covariate
     # with pytest.raises(InstrumentsAsCovarsError):
@@ -306,6 +306,6 @@ def test_deprecation_errors():
 
     data = get_data()
     with pytest.raises(FeatureDeprecationError):
-        feols("Y ~ i(f1)", data, i_ref1 = 1)
+        feols("Y ~ i(f1)", data, i_ref1=1)
     with pytest.raises(FeatureDeprecationError):
-        fepois("Y ~ i(f1)", data, i_ref1 = 1)
+        fepois("Y ~ i(f1)", data, i_ref1=1)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -5,10 +5,12 @@ import pytest
 from pyfixest.errors import (
     DuplicateKeyError,
     InstrumentsAsCovarsError,
+    EndogVarsAsCovarsError,
     MultiEstNotSupportedError,
     NanInClusterVarError,
     UnderDeterminedIVError,
     VcovTypeNotSupportedError,
+    FeatureDeprecationError,
 )
 from pyfixest.estimation.estimation import feols, fepois
 from pyfixest.estimation.FormulaParser import FixestFormulaParser
@@ -84,15 +86,8 @@ def test_iv_errors():
     with pytest.raises(InstrumentsAsCovarsError):
         feols(fml="Y ~ X1 | Z1  ~ X1 + X2", data=data)
     # endogenous variable specified as covariate
-    # with pytest.raises(EndogVarsAsCovarsError):
-    #    feols(fml="Y ~ Z1 | Z1  ~ X1", data=data)
-    # test equivalence
-    fit1 = feols(fml="Y ~ Z1 | Z1  ~ X1", data=data)
-    fit2 = feols(fml="Y ~ 1 | Z1  ~ X1", data=data)
-    np.testing.assert_allclose(fit1.coef().values, fit2.coef().values)
-    fit3 = feols(fml="Y ~ X2 + Z1 | Z1  ~ X1", data=data)
-    fit4 = feols(fml="Y ~ X2  | Z1  ~ X1", data=data)
-    np.testing.assert_allclose(fit3.coef().values, fit4.coef().values)
+    with pytest.raises(EndogVarsAsCovarsError):
+       feols(fml="Y ~ Z1 | Z1  ~ X1", data=data)
 
     # instrument specified as covariate
     # with pytest.raises(InstrumentsAsCovarsError):
@@ -305,3 +300,12 @@ def test_errors_confint():
     fit = feols("Y ~ X1", data=data)
     with pytest.raises(ValueError):
         fit.confint(alpha=0.5, keep=["abababa"])
+
+
+def test_deprecation_errors():
+
+    data = get_data()
+    with pytest.raises(FeatureDeprecationError):
+        feols("Y ~ i(f1)", data, i_ref1 = 1)
+    with pytest.raises(FeatureDeprecationError):
+        fepois("Y ~ i(f1)", data, i_ref1 = 1)


### PR DESCRIPTION
- Fix a few small bugs. 
- Throw an error when endog. variables are specified in the set of covariates. 
- Add a deprecation warning in case of use of `i_ref1`. 