### PR TITLE
Add pre-commit-ci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autofix_prs: false
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
@@ -26,6 +29,6 @@ repos:
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.8.5
     hooks:
-    - id: nbqa-ruff
-      args: ["--fix", "--output-format=full"]
-      files: ^docs/.*\.ipynb$
+      - id: nbqa-ruff
+        args: ["--fix", "--output-format=full"]
+        files: ^docs/.*\.ipynb$


### PR DESCRIPTION
This PR suggests using pre-commit-ci (https://pre-commit.ci/) so that the versions of the pre-commit hooks get automatically updated weekly. If any package needs an update, a pre-commit PR will be opened every week. This is much better than doing it by hand and ensuring the lint and code style do not break without warning.  Here is an example of such PR from one of my projects: https://github.com/pymc-labs/pymc-marketing/pull/642

Once (and if) this PR is merged, @s3alfisc you need to sign up with GitHub and approve the integration of the pre-commit app here: https://pre-commit.ci/

**Important: pre-commit.ci will always be free for open source repositories.** (from the documentation)

