### PR TITLE
Add colors to tests and cov report

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,14 @@ jupyterlab = "^4.0.12"
 jupytext = "^1.16.1"
 
 [tool.pytest.ini_options]
+addopts = [
+    "-v",
+    "--strict-markers",
+    "--strict-config",
+    "--cov=pyfixest",
+    "--cov-report=term-missing",
+    "--color=yes",
+]
 markers = [
     "extended: mark test to be part of the extended test suite"
 ]


### PR DESCRIPTION
Here are some suggestions to make the test reports more colorful and also get code coverage reports on the GitHub actions runs.

This is how it looks:
![image](https://github.com/s3alfisc/pyfixest/assets/22996444/80bcd91b-e5ac-41a5-b65d-44a274942b48)

This is especially helpful when some test fails because you can easily locate it :) 