### PR TITLE
Fix small bugs with weights

### DIFF
--- a/pyfixest/estimation/feols_.py
+++ b/pyfixest/estimation/feols_.py
@@ -1432,7 +1432,7 @@ class Feols:
             self._r2 = 1 - (ssu / ssy)
             self._adj_r2 = 1 - (ssu / ssy) * _adj_factor
 
-        if _has_fixef:
+        if _has_fixef and not _has_weights:
             ssy_within = np.sum((_Y_within - np.mean(_Y_within)) ** 2)
             self._r2_within = 1 - (ssu / ssy_within)
             self._r2_adj_within = 1 - (ssu / ssy_within) * _adj_factor

--- a/pyfixest/report/summarize.py
+++ b/pyfixest/report/summarize.py
@@ -128,7 +128,7 @@ def etable(
         _nobs_kwargs["scientific_notation"] = False
         nobs_list.append(_number_formatter(model._N, **_nobs_kwargs))
 
-        if model._r2 is not None:
+        if not np.isnan(model._r2):
             r2_list.append(_number_formatter(model._r2, **kwargs))
         else:
             r2_list.append("-")


### PR DESCRIPTION
- Do not report np.nan in `etable()` as r2 value for WLS
- Do not compute R2 values at all for WLS with fixed effects